### PR TITLE
chore(desktop): preserve skill header design prototypes

### DIFF
--- a/apps/desktop/skill-header-prototype.html
+++ b/apps/desktop/skill-header-prototype.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/skill-studio-logo.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skill header prototype</title>
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+      body {
+        background-color: #0f0f0f;
+        color: #f6f6f6;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/prototypes/skill-header/main.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/prototypes/skill-header/HeaderControls.tsx
+++ b/apps/desktop/src/prototypes/skill-header/HeaderControls.tsx
@@ -1,0 +1,108 @@
+// ============================================================================
+// PROTOTYPE. Shared header controls so every variant has working Back,
+// Assistant, and overflow — not a shared layout.
+// ============================================================================
+
+import { useEffect, useState } from "react";
+import { ArrowLeft, MoreHorizontal, PanelRight } from "lucide-react";
+import { MenuControl, MenuItem, MenuSeparator } from "../../components/ui/MenuControl";
+
+export function useHeaderFeedback() {
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const id = window.setTimeout(() => setFeedback(null), 1400);
+    return () => window.clearTimeout(id);
+  }, [feedback]);
+
+  return { feedback, setFeedback };
+}
+
+export function BackButton({ flashed, onBack }: { flashed: boolean; onBack: () => void }) {
+  return (
+    <button
+      type="button"
+      className={`flex shrink-0 items-center gap-1.5 border-0 bg-transparent p-1 text-small transition-colors duration-150 ease-out ${
+        flashed ? "text-text-primary" : "text-text-tertiary hover:text-text-primary"
+      }`}
+      onClick={onBack}
+      aria-label="Back to Skills"
+    >
+      <ArrowLeft size={16} />
+      <span>{flashed ? "Back to Skills" : "Skills"}</span>
+    </button>
+  );
+}
+
+export function AssistantButton({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      className="flex h-(--control-height) items-center gap-1.5 rounded-sm border border-border px-3 text-body text-text-secondary transition-colors duration-150 ease-out hover:bg-bg-tertiary hover:text-text-primary aria-expanded:border-border-focus aria-expanded:text-accent"
+      onClick={onToggle}
+      aria-expanded={open}
+      aria-controls={open ? "skill-header-prototype-assistant" : undefined}
+    >
+      <PanelRight size={16} />
+      <span>{open ? "Hide assistant" : "Assistant"}</span>
+    </button>
+  );
+}
+
+export function OverflowMenu({ onAction }: { onAction: (label: string) => void }) {
+  return (
+    <MenuControl
+      triggerClassName="flex h-(--control-height) w-(--control-height) cursor-pointer items-center justify-center rounded-sm border border-border text-text-secondary transition-colors duration-150 ease-out hover:bg-bg-tertiary hover:text-text-primary"
+      triggerAriaLabel="More actions"
+      trigger={<MoreHorizontal size={16} />}
+      align="end"
+    >
+      <MenuItem closeOnClick onClick={() => onAction("Revealed in Finder")}>
+        Reveal in Finder
+      </MenuItem>
+      <MenuItem closeOnClick onClick={() => onAction("Opened in editor")}>
+        Open in editor
+      </MenuItem>
+      <MenuItem closeOnClick onClick={() => onAction("Copied path")}>
+        Copy path
+      </MenuItem>
+      <MenuSeparator />
+      <MenuItem closeOnClick onClick={() => onAction("Parked skill")}>
+        Park skill
+      </MenuItem>
+      <MenuItem closeOnClick onClick={() => onAction("Forked to local copy")}>
+        Fork to local copy
+      </MenuItem>
+      <MenuSeparator />
+      <MenuItem closeOnClick variant="destructive" onClick={() => onAction("Remove queued")}>
+        Remove
+      </MenuItem>
+    </MenuControl>
+  );
+}
+
+export function HeaderActionCluster({
+  assistantOpen,
+  onToggleAssistant,
+  onAction,
+}: {
+  assistantOpen: boolean;
+  onToggleAssistant: () => void;
+  onAction: (label: string) => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      <AssistantButton open={assistantOpen} onToggle={onToggleAssistant} />
+      <OverflowMenu onAction={onAction} />
+    </div>
+  );
+}
+
+export function HeaderStatus({ message }: { message: string | null }) {
+  return (
+    <p className="m-0 min-h-[1.25rem] text-caption text-accent" role="status" aria-live="polite">
+      {message ?? ""}
+    </p>
+  );
+}

--- a/apps/desktop/src/prototypes/skill-header/ProvenanceRail.tsx
+++ b/apps/desktop/src/prototypes/skill-header/ProvenanceRail.tsx
@@ -1,0 +1,73 @@
+// ============================================================================
+// PROTOTYPE. Variant 1: Provenance Rail — split axis.
+// Left: identity and purpose only.
+// Right: Source, Freshness, Activity, Footprint as a labeled rail.
+// No location, harness, scope, path, or invocation in this header.
+// ============================================================================
+
+import type { ReactNode } from "react";
+import { BackButton, HeaderActionCluster, HeaderStatus } from "./HeaderControls";
+import type { SkillHeaderVariantProps } from "./fixture";
+
+function RailFact({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <dt className="text-caption font-medium tracking-[0.08em] text-text-tertiary uppercase">
+        {label}
+      </dt>
+      <dd className="m-0 text-body text-text-primary">{children}</dd>
+    </div>
+  );
+}
+
+export function ProvenanceRail({
+  skill,
+  assistantOpen,
+  feedback,
+  onBack,
+  onToggleAssistant,
+  onAction,
+}: SkillHeaderVariantProps) {
+  return (
+    <header className="flex w-full flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <BackButton flashed={feedback === "Returned to Skills"} onBack={onBack} />
+        <HeaderActionCluster
+          assistantOpen={assistantOpen}
+          onToggleAssistant={onToggleAssistant}
+          onAction={onAction}
+        />
+      </div>
+
+      <div className="grid w-full grid-cols-1 gap-8 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(240px,32%)]">
+        <div className="min-w-0">
+          <h1 className="text-display font-semibold tracking-tight text-text-primary">
+            {skill.name}
+          </h1>
+          <p className="mt-4 text-body leading-[1.55] text-text-secondary">{skill.description}</p>
+        </div>
+
+        <dl className="flex flex-col gap-4 border-t border-border-subtle pt-4 min-[900px]:border-t-0 min-[900px]:border-l min-[900px]:pt-0 min-[900px]:pl-6">
+          <RailFact label="Source">
+            <span className="block font-medium text-text-primary">{skill.sourceKind}</span>
+            <span className="block font-mono text-small text-text-tertiary">{skill.source}</span>
+          </RailFact>
+          <RailFact label="Freshness">
+            <span className="block font-medium text-text-primary">{skill.updateState}</span>
+            <span className="block text-small text-text-tertiary">Edited {skill.edited}</span>
+            <span className="block text-small text-text-tertiary">Installed {skill.installed}</span>
+          </RailFact>
+          <RailFact label="Activity">
+            <span className="block text-text-primary">{skill.uses}</span>
+          </RailFact>
+          <RailFact label="Footprint">
+            <span className="block text-text-primary">{skill.size}</span>
+            <span className="block text-small text-text-tertiary">{skill.tokens}</span>
+          </RailFact>
+        </dl>
+      </div>
+
+      <HeaderStatus message={feedback} />
+    </header>
+  );
+}

--- a/apps/desktop/src/prototypes/skill-header/SignalStrip.tsx
+++ b/apps/desktop/src/prototypes/skill-header/SignalStrip.tsx
@@ -1,0 +1,78 @@
+// ============================================================================
+// PROTOTYPE. Variant 2: Signal Strip — horizontal-density axis.
+// Full-width identity and description, then a compact labeled strip:
+// Source, Status, Activity, Footprint. No rail and no enclosing card.
+// No location, harness, scope, path, or invocation in this header.
+// ============================================================================
+
+import type { ReactNode } from "react";
+import { BackButton, HeaderActionCluster, HeaderStatus } from "./HeaderControls";
+import type { SkillHeaderVariantProps } from "./fixture";
+
+function StripCell({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1 border-b border-border-subtle pb-3 pr-0 min-[900px]:border-b-0 min-[900px]:border-r min-[900px]:pr-6 min-[900px]:pb-0 min-[900px]:last:border-r-0 min-[900px]:last:pr-0">
+      <dt className="text-caption font-medium tracking-[0.08em] text-text-tertiary uppercase">
+        {label}
+      </dt>
+      <dd className="m-0 min-w-0 text-small text-text-primary">{children}</dd>
+    </div>
+  );
+}
+
+export function SignalStrip({
+  skill,
+  assistantOpen,
+  feedback,
+  onBack,
+  onToggleAssistant,
+  onAction,
+}: SkillHeaderVariantProps) {
+  return (
+    <header className="flex w-full flex-col gap-5 border-b border-border-subtle pb-6">
+      <div className="flex items-center justify-between gap-4">
+        <BackButton flashed={feedback === "Returned to Skills"} onBack={onBack} />
+        <HeaderActionCluster
+          assistantOpen={assistantOpen}
+          onToggleAssistant={onToggleAssistant}
+          onAction={onAction}
+        />
+      </div>
+
+      <div>
+        <h1 className="text-display font-semibold tracking-tight text-text-primary">
+          {skill.name}
+        </h1>
+        <p className="mt-3 text-body leading-[1.55] text-text-secondary">{skill.description}</p>
+      </div>
+
+      <dl className="grid w-full grid-cols-2 gap-x-6 gap-y-4 pt-1 min-[900px]:grid-cols-4 min-[900px]:gap-x-0 min-[900px]:gap-y-0">
+        <StripCell label="Source">
+          <span className="block font-medium text-text-primary">{skill.sourceKind}</span>
+          <span className="block truncate font-mono text-caption text-text-tertiary">
+            {skill.source}
+          </span>
+        </StripCell>
+        <StripCell label="Status">
+          <span className="block font-medium text-text-primary">{skill.updateState}</span>
+          <span className="block truncate text-caption text-text-tertiary">
+            Edited {skill.edited}
+          </span>
+          <span className="block truncate text-caption text-text-tertiary">
+            Installed {skill.installed}
+          </span>
+        </StripCell>
+        <StripCell label="Activity">
+          <span className="block font-medium text-text-primary">{skill.uses}</span>
+          <span className="block text-caption text-text-tertiary">Rolling 30 days</span>
+        </StripCell>
+        <StripCell label="Footprint">
+          <span className="block font-medium text-text-primary">{skill.size}</span>
+          <span className="block text-caption text-text-tertiary">{skill.tokens}</span>
+        </StripCell>
+      </dl>
+
+      <HeaderStatus message={feedback} />
+    </header>
+  );
+}

--- a/apps/desktop/src/prototypes/skill-header/SkillHeaderHarness.tsx
+++ b/apps/desktop/src/prototypes/skill-header/SkillHeaderHarness.tsx
@@ -1,0 +1,150 @@
+// ============================================================================
+// PROTOTYPE. Surrounding chrome only: sidebar, Locations + Invocation, assistant
+// drawer. Variants own the installed skill header and must not repeat these facts.
+// ============================================================================
+
+import { LayoutDashboard, Plus, RefreshCw, Search } from "lucide-react";
+import { HarnessIcon } from "../../components/ui/HarnessIcon";
+import type { SkillHeaderFixture } from "./fixture";
+
+function SidebarItem({ label, active, count }: { label: string; active: boolean; count?: string }) {
+  return (
+    <div
+      className={`grid h-[30px] w-full grid-cols-[15px_minmax(0,1fr)_auto] items-center gap-2 rounded-sm px-2.5 text-left text-body ${
+        active ? "bg-accent-soft text-text-primary" : "text-text-secondary"
+      }`}
+    >
+      {label === "Home" ? <LayoutDashboard size={15} /> : <Search size={15} />}
+      <span className="min-w-0 truncate">{label}</span>
+      {count ? (
+        <span className="text-right text-caption tabular-nums text-text-tertiary">{count}</span>
+      ) : null}
+    </div>
+  );
+}
+
+export function PrototypeSidebar() {
+  return (
+    <nav
+      className="flex w-60 shrink-0 flex-col border-r border-border bg-bg-secondary"
+      aria-hidden="true"
+    >
+      <div className="flex flex-col gap-px px-2.5 pt-3 pb-2.5">
+        <div className="flex h-8 items-center rounded-sm border border-border bg-bg-primary px-3 text-body text-text-quaternary">
+          Search skills…
+        </div>
+        <div className="mt-1.5 flex h-[30px] items-center justify-center gap-1.5 rounded-sm bg-accent-soft text-body text-text-primary">
+          <Plus size={15} />
+          Add skill
+        </div>
+      </div>
+      <div className="flex flex-col gap-px px-2.5 pb-2.5">
+        <SidebarItem label="Home" active={false} />
+        <SidebarItem label="Skills" active count="12" />
+        <SidebarItem label="Activity" active={false} />
+      </div>
+      <div className="mt-auto flex items-center gap-1.5 border-t border-border-subtle px-2.5 py-2 text-caption text-text-tertiary">
+        <RefreshCw size={13} />
+        Sync
+      </div>
+    </nav>
+  );
+}
+
+function InvocationControl({ selected }: { selected: "both" | "user" | "model" }) {
+  return (
+    <div className="flex items-center rounded-sm border border-border bg-bg-secondary p-0.5 text-caption">
+      <span
+        className={
+          selected === "both"
+            ? "rounded-[3px] bg-bg-primary px-2 py-0.5 font-medium text-text-primary shadow-xs"
+            : "px-2 py-0.5 text-text-tertiary"
+        }
+      >
+        Both
+      </span>
+      <span
+        className={
+          selected === "user"
+            ? "rounded-[3px] bg-bg-primary px-2 py-0.5 font-medium text-text-primary shadow-xs"
+            : "px-2 py-0.5 text-text-tertiary"
+        }
+      >
+        User only
+      </span>
+      <span
+        className={
+          selected === "model"
+            ? "rounded-[3px] bg-bg-primary px-2 py-0.5 font-medium text-text-primary shadow-xs"
+            : "px-2 py-0.5 text-text-tertiary"
+        }
+      >
+        Model only
+      </span>
+    </div>
+  );
+}
+
+export function LocationsStart({ skill }: { skill: SkillHeaderFixture }) {
+  const sharedPath = `~/.agents/skills/${skill.name}`;
+  const claudePath = `~/.claude/skills/${skill.name}`;
+
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border border-border-subtle p-4">
+      <div className="text-body font-semibold text-text-primary">Locations</div>
+      <div className="-mx-2 mt-1 flex flex-col">
+        <div className="flex items-center gap-2 px-2 py-2 text-small">
+          <HarnessIcon harness="shared" size={16} />
+          <span className="font-medium text-text-primary">Shared</span>
+          <span className="font-mono text-caption text-text-tertiary">{sharedPath}</span>
+          <span className="ml-auto text-caption text-text-tertiary">{skill.scope}</span>
+        </div>
+        <div className="flex items-center gap-2 px-2 py-2 text-small">
+          <HarnessIcon harness="claude-code" size={16} />
+          <span className="font-medium text-text-primary">Claude Code</span>
+          <span className="font-mono text-caption text-text-tertiary">{claudePath}</span>
+          <span className="ml-auto text-caption text-text-tertiary">symlink</span>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-1.5 border-t border-border-subtle pt-3">
+        <div className="text-caption font-medium tracking-[0.08em] text-text-tertiary uppercase">
+          Invocation
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-2 text-small">
+            <HarnessIcon harness="shared" size={16} />
+            <span className="min-w-0 truncate text-text-primary">Shared ({sharedPath})</span>
+          </div>
+          <InvocationControl selected="both" />
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-2 text-small">
+            <HarnessIcon harness="claude-code" size={16} />
+            <span className="min-w-0 truncate text-text-primary">Claude Code ({claudePath})</span>
+          </div>
+          <InvocationControl selected="both" />
+        </div>
+        <p className="m-0 text-caption text-text-tertiary">
+          Available to both model tool calling and explicit user invocation.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function PrototypeAssistant({ open }: { open: boolean }) {
+  if (!open) return null;
+  return (
+    <aside
+      id="skill-header-prototype-assistant"
+      className="flex w-80 shrink-0 flex-col border-l border-border bg-bg-secondary p-5"
+    >
+      <h2 className="text-heading font-semibold text-text-primary">Assistant</h2>
+      <p className="mt-2 text-body leading-[1.55] text-text-secondary">
+        Ask about visual-recap, compare copies, or draft a recap block. This panel is harness chrome
+        so the header toggle has somewhere to go.
+      </p>
+    </aside>
+  );
+}

--- a/apps/desktop/src/prototypes/skill-header/SourceLedger.tsx
+++ b/apps/desktop/src/prototypes/skill-header/SourceLedger.tsx
@@ -1,0 +1,83 @@
+// ============================================================================
+// PROTOTYPE. Variant 3: Source Ledger — lifecycle axis.
+// Identity and purpose on the left. Quiet right panel: repository, manager,
+// installed date, last local edit, update state; usage and size secondary.
+// No location, harness, scope, path, or invocation in this header.
+// ============================================================================
+
+import type { ReactNode } from "react";
+import { BackButton, HeaderActionCluster, HeaderStatus } from "./HeaderControls";
+import type { SkillHeaderVariantProps } from "./fixture";
+
+function LedgerRow({
+  label,
+  secondary,
+  children,
+}: {
+  label: string;
+  secondary?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-border-subtle pb-2 last:border-b-0 last:pb-0">
+      <dt className={`text-caption ${secondary ? "text-text-quaternary" : "text-text-tertiary"}`}>
+        {label}
+      </dt>
+      <dd
+        className={`m-0 text-right text-small ${secondary ? "text-text-tertiary" : "text-text-primary"}`}
+      >
+        {children}
+      </dd>
+    </div>
+  );
+}
+
+export function SourceLedger({
+  skill,
+  assistantOpen,
+  feedback,
+  onBack,
+  onToggleAssistant,
+  onAction,
+}: SkillHeaderVariantProps) {
+  return (
+    <header className="flex w-full flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <BackButton flashed={feedback === "Returned to Skills"} onBack={onBack} />
+        <HeaderActionCluster
+          assistantOpen={assistantOpen}
+          onToggleAssistant={onToggleAssistant}
+          onAction={onAction}
+        />
+      </div>
+
+      <div className="grid w-full grid-cols-1 gap-8 min-[900px]:grid-cols-[minmax(0,1.35fr)_minmax(260px,1fr)]">
+        <div className="min-w-0">
+          <h1 className="text-display font-semibold tracking-tight text-text-primary">
+            {skill.name}
+          </h1>
+          <p className="mt-4 text-body leading-[1.55] text-text-secondary">{skill.description}</p>
+        </div>
+
+        <dl className="flex flex-col gap-2 rounded-lg bg-bg-secondary p-4">
+          <LedgerRow label="Repository">
+            <span className="font-mono">{skill.source}</span>
+          </LedgerRow>
+          <LedgerRow label="Manager">{skill.sourceKind}</LedgerRow>
+          <LedgerRow label="Installed">{skill.installed}</LedgerRow>
+          <LedgerRow label="Last local edit">{skill.edited}</LedgerRow>
+          <LedgerRow label="Update state">{skill.updateState}</LedgerRow>
+          <LedgerRow label="Usage" secondary>
+            {skill.uses}
+          </LedgerRow>
+          <LedgerRow label="Size" secondary>
+            {skill.size}
+            <span className="mt-0.5 block text-caption text-text-quaternary">{skill.tokens}</span>
+          </LedgerRow>
+        </dl>
+      </div>
+
+      <HeaderStatus message={feedback} />
+    </header>
+  );
+}

--- a/apps/desktop/src/prototypes/skill-header/fixture.ts
+++ b/apps/desktop/src/prototypes/skill-header/fixture.ts
@@ -1,0 +1,43 @@
+// ============================================================================
+// PROTOTYPE. Throwaway fixture for the installed skill header exploration.
+// visual-recap is the sample skill. Location / harness / invocation live in
+// the harness below the header, not in this payload's header variants.
+// ============================================================================
+
+export interface SkillHeaderFixture {
+  name: string;
+  source: string;
+  sourceKind: string;
+  description: string;
+  size: string;
+  tokens: string;
+  uses: string;
+  edited: string;
+  installed: string;
+  updateState: string;
+  scope: string;
+}
+
+export interface SkillHeaderVariantProps {
+  skill: SkillHeaderFixture;
+  assistantOpen: boolean;
+  feedback: string | null;
+  onBack: () => void;
+  onToggleAssistant: () => void;
+  onAction: (label: string) => void;
+}
+
+export const SKILL_HEADER_FIXTURE: SkillHeaderFixture = {
+  name: "visual-recap",
+  source: "kentcdodds/kcd-skills",
+  sourceKind: "skills.sh",
+  description:
+    "Generate and maintain the system recap block in a PR description — a GitHub-rendered visual summary of which system primitives a change touches, how risky it is, and what changed. Use when planning a non-trivial change (plan mode), when creating or updating a pull request (recap mode), or when the user asks for a visual recap, visual plan, system review, or PR recap.",
+  size: "7.8 KB",
+  tokens: "1.5k tokens",
+  uses: "0 uses in 30 days",
+  edited: "just now",
+  installed: "Sep 4 2026",
+  updateState: "Current",
+  scope: "Global",
+};

--- a/apps/desktop/src/prototypes/skill-header/main.tsx
+++ b/apps/desktop/src/prototypes/skill-header/main.tsx
@@ -1,0 +1,145 @@
+// ============================================================================
+// PROTOTYPE. Throwaway. Three variants of the installed skill header,
+// switchable via ?v=1|2|3. Isolated Vite entry — not imported by production.
+// ============================================================================
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { stampInitialTheme } from "../../lib/theme";
+import { SKILL_HEADER_FIXTURE } from "./fixture";
+import { useHeaderFeedback } from "./HeaderControls";
+import { ProvenanceRail } from "./ProvenanceRail";
+import { SignalStrip } from "./SignalStrip";
+import { LocationsStart, PrototypeAssistant, PrototypeSidebar } from "./SkillHeaderHarness";
+import { SourceLedger } from "./SourceLedger";
+import "../../App.css";
+import "./picker.css";
+
+const VARIANTS = [
+  { name: "Provenance Rail", Component: ProvenanceRail },
+  { name: "Signal Strip", Component: SignalStrip },
+  { name: "Source Ledger", Component: SourceLedger },
+] as const;
+
+function initialVariant() {
+  const value = Number(new URLSearchParams(location.search).get("v"));
+  return Number.isInteger(value) && value >= 1 && value <= VARIANTS.length ? value - 1 : 0;
+}
+
+function SkillHeaderPrototype() {
+  const [current, setCurrent] = useState(initialVariant);
+  const [assistantOpen, setAssistantOpen] = useState(false);
+  const { feedback, setFeedback } = useHeaderFeedback();
+  const picker = useRef<HTMLElement>(null);
+  const highlight = useRef<HTMLSpanElement>(null);
+  const Variant = VARIANTS[current].Component;
+
+  const select = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= VARIANTS.length) return;
+      setCurrent(index);
+      setAssistantOpen(false);
+      setFeedback(null);
+      const url = new URL(location.href);
+      url.searchParams.set("v", String(index + 1));
+      history.replaceState(null, "", url);
+    },
+    [setFeedback],
+  );
+
+  useLayoutEffect(() => {
+    const move = () => {
+      const items = picker.current?.querySelectorAll<HTMLElement>("button.proto-picker-item");
+      const item = items?.[current];
+      if (item && highlight.current) {
+        highlight.current.style.width = `${item.offsetWidth}px`;
+        highlight.current.style.transform = `translateX(${item.offsetLeft}px)`;
+      }
+    };
+    move();
+    window.addEventListener("resize", move);
+    return () => window.removeEventListener("resize", move);
+  }, [current]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() =>
+      requestAnimationFrame(() => picker.current?.setAttribute("data-ready", "")),
+    );
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  useEffect(() => {
+    const keydown = (event: KeyboardEvent) => {
+      if (
+        !(event.target instanceof HTMLElement) ||
+        /^(INPUT|TEXTAREA|SELECT)$/.test(event.target.tagName) ||
+        event.target.isContentEditable ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+      const number = Number(event.key);
+      if (number >= 1 && number <= VARIANTS.length) select(number - 1);
+      else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        select((current + 1) % VARIANTS.length);
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        select((current - 1 + VARIANTS.length) % VARIANTS.length);
+      }
+    };
+    document.addEventListener("keydown", keydown);
+    return () => document.removeEventListener("keydown", keydown);
+  }, [current, select]);
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-bg-primary text-text-primary">
+      <PrototypeSidebar />
+      <main className="relative min-w-0 flex-1 overflow-y-auto">
+        <div className="flex w-full flex-col gap-6 px-8 pt-7 pb-24">
+          <Variant
+            key={current}
+            skill={SKILL_HEADER_FIXTURE}
+            assistantOpen={assistantOpen}
+            feedback={feedback}
+            onBack={() => setFeedback("Returned to Skills")}
+            onToggleAssistant={() => {
+              const next = !assistantOpen;
+              setAssistantOpen(next);
+              setFeedback(next ? "Assistant open" : "Assistant closed");
+            }}
+            onAction={setFeedback}
+          />
+          <LocationsStart skill={SKILL_HEADER_FIXTURE} />
+        </div>
+      </main>
+      <PrototypeAssistant open={assistantOpen} />
+      <nav ref={picker} className="proto-picker" aria-label="Prototype variants">
+        <span ref={highlight} className="proto-picker-highlight" aria-hidden="true" />
+        {VARIANTS.map((variant, index) => (
+          <button
+            key={variant.name}
+            type="button"
+            className="proto-picker-item"
+            data-active={current === index ? "" : undefined}
+            aria-current={current === index ? "true" : undefined}
+            onClick={() => select(index)}
+          >
+            {variant.name}
+          </button>
+        ))}
+      </nav>
+    </div>
+  );
+}
+
+stampInitialTheme();
+
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Skill header prototype root element #root is missing");
+}
+createRoot(rootElement).render(<SkillHeaderPrototype />);

--- a/apps/desktop/src/prototypes/skill-header/picker.css
+++ b/apps/desktop/src/prototypes/skill-header/picker.css
@@ -1,0 +1,97 @@
+.proto-picker {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(10, 10, 10, 0.82);
+  -webkit-backdrop-filter: blur(12px) saturate(1.4);
+  backdrop-filter: blur(12px) saturate(1.4);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08) inset,
+    0 8px 24px rgba(0, 0, 0, 0.24),
+    0 2px 6px rgba(0, 0, 0, 0.12);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.proto-picker-highlight {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  will-change: transform;
+}
+
+/* The slide is enabled only after first paint (data-ready), so load doesn't animate. */
+.proto-picker[data-ready] .proto-picker-highlight {
+  transition:
+    transform 250ms cubic-bezier(0.23, 1, 0.32, 1),
+    width 250ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proto-picker[data-ready] .proto-picker-highlight {
+    transition: none;
+  }
+}
+
+.proto-picker-item {
+  position: relative; /* sits above the highlight */
+  display: flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  font: inherit;
+  cursor: pointer;
+  transition: color 150ms ease-out;
+}
+
+.proto-picker-item:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.proto-picker-item:active {
+  transform: scale(0.97);
+}
+
+.proto-picker-item:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.proto-picker-item[data-active] {
+  color: #fff;
+}
+
+.proto-picker-divider {
+  width: 1px;
+  height: 16px;
+  margin: 0 4px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.proto-picker-replay {
+  padding: 0 10px;
+  font-size: 14px;
+}
+
+.proto-picker[data-position="top"] {
+  bottom: auto;
+  top: 24px;
+}


### PR DESCRIPTION
Preserves the Provenance Rail, Signal Strip, and Source Ledger header experiments in an isolated Vite entry at `/skill-header-prototype.html?v=1` (variants 1–3). The prototype has its own fixture and picker; it is not imported by the production app.

PR #49 already implements the production source ledger. This draft keeps the other local design work available for comparison without replacing that implementation. The desktop TypeScript check passes.
