### PR TITLE
fix(desktop): clarify sync and skill visibility feedback

### DIFF
--- a/apps/desktop/src-tauri/src/skills/event_commands.rs
+++ b/apps/desktop/src-tauri/src/skills/event_commands.rs
@@ -189,7 +189,7 @@ pub fn set_shared_harness_skill_enabled(
             .unwrap_or(false);
         if is_whole_dir_link {
             return Err(format!(
-                "{} is a link to the shared folder; convert it to per-skill links first",
+                "{} is a link to the Universal folder; convert it to per-skill links first",
                 root.display()
             ));
         }

--- a/apps/desktop/src-tauri/src/skills/skill_add.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_add.rs
@@ -2760,7 +2760,7 @@ mod tests {
             warning.starts_with("Installed, but could not turn it off for Claude Code:"),
             "{warning}"
         );
-        assert!(warning.contains("whole shared folder"), "{warning}");
+        assert!(warning.contains("whole Universal folder"), "{warning}");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/skills/skill_fork.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_fork.rs
@@ -552,7 +552,7 @@ fn validate_fork_path(home: &Path, name: &str, path: &Path) -> Result<(), String
         .map_err(|e| format!("Failed to resolve {}: {e}", expected.display()))?;
     if canonical_given != canonical_expected {
         return Err(
-            "Only the shared-folder copy (~/.agents/skills/<name>) can be forked".to_string(),
+            "Only the Universal-folder copy (~/.agents/skills/<name>) can be forked".to_string(),
         );
     }
     Ok(())
@@ -1602,7 +1602,7 @@ mod tests {
             &NeverCalledLookup,
         )
         .unwrap_err();
-        assert!(err.contains("shared-folder"));
+        assert!(err.contains("Universal-folder"));
         assert_eq!(ledger.remove_calls.lock().unwrap().len(), 0);
     }
 

--- a/apps/desktop/src-tauri/src/skills/skill_harness_disable.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_harness_disable.rs
@@ -467,7 +467,7 @@ fn set_claude_code_enabled(
 
     match claude_link_state_at(link_path) {
         ClaudeLinkState::WholeDir => Err(
-            "Claude Code reads the whole shared folder for skills, not a per-skill symlink - it cannot be disabled for just this skill".to_string(),
+            "Claude Code reads the whole Universal folder for skills, not a per-skill symlink - it cannot be disabled for just this skill".to_string(),
         ),
         ClaudeLinkState::None => {
             Err(format!("\"{name}\" is not deployed to Claude Code via a per-skill symlink"))
@@ -562,7 +562,7 @@ pub fn set_harness_enabled_with(
         }
         "claude-code" => Err("Claude Code visibility needs an exact deployment target".to_string()),
         "pi" | "cursor" | "grok-build" => Err(format!(
-            "{agent} has no per-skill disable - it reads the shared skills folder directly"
+            "{agent} has no per-skill disable - it reads the Universal folder directly"
         )),
         other => Err(format!("Unknown harness: {other}")),
     }
@@ -1254,7 +1254,7 @@ mod tests {
             false,
         )
         .unwrap_err();
-        assert!(err.contains("whole shared folder"));
+        assert!(err.contains("whole Universal folder"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/skills/skill_park.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_park.rs
@@ -219,7 +219,7 @@ fn park_skill_impl(
     let shared_dir = shared_skill_dir(home, name);
     if !shared_dir.is_dir() {
         return Err(format!(
-            "\"{name}\" is not deployed in the shared folder (~/.agents/skills/{name})"
+            "\"{name}\" is not deployed in the Universal folder (~/.agents/skills/{name})"
         ));
     }
 
@@ -597,7 +597,7 @@ mod tests {
     fn park_refuses_when_not_deployed_in_shared_folder() {
         let tmp = tempfile::tempdir().unwrap();
         let err = park_skill_with(tmp.path(), "find-bugs", SourceKind::Manual, now()).unwrap_err();
-        assert!(err.contains("not deployed in the shared folder"));
+        assert!(err.contains("not deployed in the Universal folder"));
     }
 
     #[test]

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -215,6 +215,9 @@ body {
 :focus-visible {
   outline: 2px solid var(--color-border-focus);
   outline-offset: 2px;
+}
+:where(input[data-slot="input"], textarea[data-slot="textarea"]):focus-visible {
+  outline: none;
 } /* One frame of frozen transitions during a theme switch, so every
      component's own transition timing doesn't turn it into a ragged
      cascade - see stampTheme in src/lib/theme.ts. */

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -29,7 +29,7 @@ import { useAppStore } from "./store/appStore";
 import "./App.css";
 
 function App() {
-  const { snapshot, isLoading, requestRescan } = useSkillSnapshot();
+  const { snapshot, emittedSnapshotRevision, isLoading, requestRescan } = useSkillSnapshot();
   const resolvedTheme = useAppStore((state) => state.resolvedTheme);
   const activeView = useAppStore((state) => state.activeView);
   const openSkill = useAppStore((state) => state.openSkill);
@@ -135,7 +135,11 @@ function App() {
   return (
     <TooltipProvider delay={400}>
       <div className="flex h-screen overflow-hidden bg-[var(--color-bg-primary)]">
-        <Sidebar snapshot={snapshot} isLoading={isLoading} requestRescan={requestRescan} />
+        <Sidebar
+          snapshot={snapshot}
+          emittedSnapshotRevision={emittedSnapshotRevision}
+          requestRescan={requestRescan}
+        />
         <main className="flex-1 overflow-y-auto">{main}</main>
 
         <AddSkillSheet />

--- a/apps/desktop/src/components/Sidebar/Sidebar.test.ts
+++ b/apps/desktop/src/components/Sidebar/Sidebar.test.ts
@@ -3,20 +3,45 @@
 // ============================================================================
 
 import { describe, expect, it } from "vitest";
-import { relativeScanTime } from "../../lib/sidebar-nav";
+import {
+  hasNewerSkillSnapshotEmission,
+  relativeScanTime,
+  rescanTooltip,
+} from "../../lib/sidebar-nav";
 
 describe("relativeScanTime", () => {
-  it("reads 'never scanned' when there is no timestamp", () => {
-    expect(relativeScanTime(undefined)).toBe("never scanned");
+  it("reads 'Never' when there is no timestamp", () => {
+    expect(relativeScanTime(undefined)).toBe("Never");
   });
 
-  it("reads 'just now' just under the one-minute boundary", () => {
+  it("reads 'Just now' just under the one-minute boundary", () => {
     const scannedAt = new Date(Date.now() - 59_000).toISOString();
-    expect(relativeScanTime(scannedAt)).toBe("just now");
+    expect(relativeScanTime(scannedAt)).toBe("Just now");
   });
 
   it("reads '1m ago' at the one-minute boundary", () => {
     const scannedAt = new Date(Date.now() - 60_000).toISOString();
     expect(relativeScanTime(scannedAt)).toBe("1m ago");
+  });
+});
+
+describe("rescanTooltip", () => {
+  it("shows 'Last sync: Never' when timestamp is missing", () => {
+    expect(rescanTooltip(undefined)).toBe("Refresh skills from disk\nLast sync: Never");
+  });
+
+  it("shows 'Last sync: Just now' for recent scans", () => {
+    const scannedAt = new Date(Date.now() - 10_000).toISOString();
+    expect(rescanTooltip(scannedAt)).toBe("Refresh skills from disk\nLast sync: Just now");
+  });
+});
+
+describe("hasNewerSkillSnapshotEmission", () => {
+  it("does not complete from an initial snapshot read", () => {
+    expect(hasNewerSkillSnapshotEmission(0, undefined)).toBe(false);
+  });
+
+  it("completes when a listener delivers a newer backend revision", () => {
+    expect(hasNewerSkillSnapshotEmission(4, 5)).toBe(true);
   });
 });

--- a/apps/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar/Sidebar.tsx
@@ -23,14 +23,18 @@ import {
 import { ownSkillsView, pluginSkillsView } from "@skill-studio/lib";
 import { defaultSkillListFilter } from "@skill-studio/lib";
 import { isFeatureEnabled } from "../../lib/feature-flags";
-import { relativeScanTime, sidebarAnchorView } from "../../lib/sidebar-nav";
+import {
+  hasNewerSkillSnapshotEmission,
+  rescanTooltip,
+  sidebarAnchorView,
+} from "../../lib/sidebar-nav";
 import { useAppStore } from "../../store/appStore";
 import { TooltipControl } from "../ui/TooltipControl";
 import type { SkillSnapshot } from "@skill-studio/lib";
 
 interface SidebarProps {
   snapshot: SkillSnapshot | undefined;
-  isLoading: boolean;
+  emittedSnapshotRevision: number | undefined;
   requestRescan: () => Promise<void>;
 }
 
@@ -40,8 +44,11 @@ interface SidebarProps {
  * non-empty), and a footer with the snapshot's age and a manual rescan
  * button.
  */
-export function Sidebar({ snapshot, isLoading, requestRescan }: SidebarProps) {
-  const [isRescanning, setIsRescanning] = useState(false);
+export function Sidebar({ snapshot, emittedSnapshotRevision, requestRescan }: SidebarProps) {
+  const [pendingRescanSnapshotRevision, setPendingRescanSnapshotRevision] = useState<number | null>(
+    null,
+  );
+  const activeRescanIdRef = useRef<symbol | null>(null);
   // Forces the footer to re-render so "just now" ages into "1m ago" and
   // beyond without waiting for the next snapshot - relativeScanTime() itself
   // stays a pure function of scannedAt and the current clock.
@@ -49,6 +56,11 @@ export function Sidebar({ snapshot, isLoading, requestRescan }: SidebarProps) {
   useEffect(() => {
     const id = setInterval(() => forceTick((n) => n + 1), 30_000);
     return () => clearInterval(id);
+  }, []);
+  useEffect(() => {
+    return () => {
+      activeRescanIdRef.current = null;
+    };
   }, []);
   const activeView = useAppStore((state) => state.activeView);
   const anchorView = sidebarAnchorView(activeView);
@@ -86,13 +98,36 @@ export function Sidebar({ snapshot, isLoading, requestRescan }: SidebarProps) {
     }
   }
 
+  useEffect(() => {
+    if (
+      activeRescanIdRef.current !== null &&
+      hasNewerSkillSnapshotEmission(
+        pendingRescanSnapshotRevision ?? undefined,
+        emittedSnapshotRevision,
+      )
+    ) {
+      activeRescanIdRef.current = null;
+      setPendingRescanSnapshotRevision(null);
+    }
+  }, [emittedSnapshotRevision, pendingRescanSnapshotRevision]);
+
   const handleRefresh = async () => {
-    setIsRescanning(true);
-    await requestRescan();
-    // Cleared when the next snapshot lands and `isLoading` flips back to false.
+    if (activeRescanIdRef.current !== null) return;
+
+    const requestId = Symbol("sidebar-rescan");
+    activeRescanIdRef.current = requestId;
+    setPendingRescanSnapshotRevision(snapshot?.revision ?? 0);
+
+    try {
+      await requestRescan();
+    } catch {
+      if (activeRescanIdRef.current !== requestId) return;
+      activeRescanIdRef.current = null;
+      setPendingRescanSnapshotRevision(null);
+    }
   };
 
-  const spinning = isRescanning && isLoading;
+  const spinning = pendingRescanSnapshotRevision !== null;
 
   const itemClass = (active: boolean) =>
     `grid h-[30px] w-full cursor-pointer grid-cols-[15px_minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 px-2.5 text-left text-body transition-colors ${
@@ -197,17 +232,16 @@ export function Sidebar({ snapshot, isLoading, requestRescan }: SidebarProps) {
       )}
 
       <div className="mt-auto flex select-none items-center justify-between gap-2 border-t border-border-subtle px-2.5 py-2">
-        <TooltipControl content="Rescan installed skills">
+        <TooltipControl content={rescanTooltip(snapshot?.scanned_at)}>
           <button
             type="button"
-            className="flex h-6 cursor-pointer items-center gap-1.5 rounded-sm border-0 bg-transparent px-1.5 text-caption text-text-tertiary transition-colors hover:enabled:bg-bg-hover hover:enabled:text-text-primary disabled:cursor-default"
+            className="flex h-6 shrink-0 cursor-pointer items-center gap-1.5 rounded-sm border-0 bg-transparent px-1.5 text-caption text-text-tertiary transition-colors hover:enabled:bg-bg-hover hover:enabled:text-text-primary disabled:cursor-default"
             onClick={handleRefresh}
             disabled={spinning}
+            aria-label={spinning ? "Syncing installed skills" : "Sync installed skills"}
           >
             <RefreshCw size={13} className={spinning ? "animate-spin" : ""} />
-            <span>
-              {spinning ? "Scanning…" : `Scanned ${relativeScanTime(snapshot?.scanned_at)}`}
-            </span>
+            <span className="whitespace-nowrap">{spinning ? "Syncing…" : "Sync"}</span>
           </button>
         </TooltipControl>
         <div className="flex items-center gap-0.5">

--- a/apps/desktop/src/components/SkillDetail/SkillLocationRow.tsx
+++ b/apps/desktop/src/components/SkillDetail/SkillLocationRow.tsx
@@ -26,6 +26,7 @@ export function SkillLocationRow({
 }) {
   const menu = rowMenu(row, scopeLabel);
   const tip = tipLines(row.conditions);
+  const isAlwaysOnReader = row.kind === "reader" && !row.hasSwitch;
   const labelTip =
     row.kind === "link" && row.deployment?.symlink_target
       ? [
@@ -65,11 +66,6 @@ export function SkillLocationRow({
         <span className="truncate text-caption text-text-tertiary">{row.caption}</span>
       </span>
       <span className="flex shrink-0 items-center gap-1">
-        {row.chip && (
-          <span className="mr-1 rounded-full bg-bg-tertiary px-1.5 py-0.5 text-caption text-text-tertiary">
-            {row.chip}
-          </span>
-        )}
         {row.hasSwitch ? (
           <SwitchControl
             checked={row.switchOn}
@@ -87,6 +83,27 @@ export function SkillLocationRow({
             }
             ariaLabel={`Enabled for ${row.harnessLabel}`}
           />
+        ) : isAlwaysOnReader ? (
+          <TooltipControl
+            content={
+              row.switchOn
+                ? `Always on because ${row.harnessLabel} has no per-skill switch.`
+                : `Off because this skill is disabled in the Universal folder.`
+            }
+          >
+            <span className="inline-flex">
+              <SwitchControl
+                checked={row.switchOn}
+                disabled
+                onCheckedChange={() => undefined}
+                ariaLabel={
+                  row.switchOn
+                    ? `Always enabled for ${row.harnessLabel}`
+                    : `Disabled for ${row.harnessLabel} while this skill is off`
+                }
+              />
+            </span>
+          </TooltipControl>
         ) : (
           <span className="w-6" aria-hidden="true" />
         )}

--- a/apps/desktop/src/components/SkillDetail/skill-location-status.test.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-location-status.test.ts
@@ -2,7 +2,11 @@
 // Skill Studio - skill-location-status tests
 // ============================================================================
 
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import { TooltipProvider } from "@skill-studio/ui";
+import { SkillLocationRow } from "./SkillLocationRow";
 import type { Deployment, InstalledSkill } from "@skill-studio/lib";
 import {
   buildInvocationFiles,
@@ -143,7 +147,6 @@ describe("buildScopeGroups", () => {
     expect(row?.kind).toBe("link");
     expect(row?.level).toBe(null);
     expect(row?.hasSwitch).toBe(true);
-    expect(row?.chip).toBe(null);
     expect(row?.conditions).toHaveLength(0);
   });
 
@@ -198,6 +201,20 @@ describe("buildScopeGroups", () => {
     expect(global.shared?.level).toBe("off");
     expect(global.shared?.conditions[0].what).toContain("Off everywhere");
     expect(global.rows.find((r) => r.harness === "claude-code")?.level).toBe("off");
+    const pi = global.rows.find((row) => row.harness === "pi")!;
+    const markup = renderToStaticMarkup(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(SkillLocationRow, {
+          row: pi,
+          scopeLabel: global.label,
+          onAction: () => undefined,
+        }),
+      ),
+    );
+    expect(markup).toContain('aria-checked="false"');
+    expect(markup).toContain('aria-label="Disabled for pi while this skill is off"');
   });
 
   it("flags parked-but-live with an error dot on the Universal folder", () => {
@@ -228,10 +245,10 @@ describe("buildScopeGroups", () => {
     const [global] = buildScopeGroups(skill);
     const pi = global.rows.find((r) => r.harness === "pi");
     expect(pi?.kind).toBe("reader");
-    expect(pi?.chip).toBe("always on");
+    expect(pi?.hasSwitch).toBe(false);
+    expect(pi?.switchOn).toBe(true);
     const codex = global.rows.find((r) => r.harness === "codex");
     expect(codex?.hasSwitch).toBe(true);
-    expect(codex?.chip).toBeNull();
   });
 
   it("keeps broken link errors on their own rows, not the folder", () => {
@@ -379,6 +396,22 @@ describe("titleLink", () => {
 });
 
 describe("rowMenu", () => {
+  it("does not duplicate switch controls with Disable menu actions", () => {
+    const shared = fixtureDeployment();
+    const claude = fixtureDeployment({
+      agent: "Claude Code",
+      is_symlink: true,
+      path: "/home/.claude/skills/find-bugs",
+    });
+    const [global] = buildScopeGroups(fixtureSkill({ deployments: [shared, claude] }));
+
+    for (const row of global.rows.filter((candidate) => candidate.hasSwitch)) {
+      const menu = rowMenu(row, global.label);
+      const labels = [...menu.entries, ...menu.danger].map((entry) => entry.label);
+      expect(labels).not.toContain(`Disable for ${row.harnessLabel}`);
+    }
+  });
+
   it("offers an independent copy only for a healthy enabled Universal-backed link", () => {
     const linked = fixtureDeployment({
       agent: "Claude Code",

--- a/apps/desktop/src/components/SkillDetail/skill-location-status.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-location-status.ts
@@ -103,7 +103,6 @@ interface BaseLocationRow {
   lifecycleTarget: LifecycleTarget;
   hasSwitch: boolean;
   switchOn: boolean;
-  chip: "always on" | null;
   invocation: InvocationPolicy | null;
 }
 
@@ -540,7 +539,6 @@ export function buildScopeGroups(skill: InstalledSkill): ScopeGroup[] {
             lifecycleTarget: { deployment_id: sharedDeployment.id },
             hasSwitch: true,
             switchOn: !sharedDeployment.disabled && !parkedScope,
-            chip: null,
             invocation: sharedDeployment.invocation ?? skill.invocation,
           };
         })()
@@ -572,7 +570,6 @@ export function buildScopeGroups(skill: InstalledSkill): ScopeGroup[] {
         lifecycleTarget: { deployment_id: d.id },
         hasSwitch: !d.symlink_is_broken && kind !== "plugin",
         switchOn: !d.disabled && !parkedScope,
-        chip: null,
         invocation: d.invocation ?? skill.invocation,
       };
     });
@@ -601,7 +598,6 @@ export function buildScopeGroups(skill: InstalledSkill): ScopeGroup[] {
           lifecycleTarget: shared.lifecycleTarget,
           hasSwitch,
           switchOn: !disabledForReader && !parkedScope,
-          chip: hasSwitch ? null : "always on",
           invocation: null,
         });
       }
@@ -870,20 +866,6 @@ export function rowMenu(
       false,
     );
   } else if (row.kind === "reader") {
-    if (row.hasSwitch && !hasOff) {
-      push(
-        {
-          label: `Disable for ${row.harnessLabel}`,
-          action: {
-            kind: "set-reader-enabled",
-            target: row.lifecycleTarget,
-            agent: row.harness,
-            enabled: false,
-          },
-        },
-        false,
-      );
-    }
     push(
       {
         label: "Reveal Universal folder in Finder",
@@ -907,15 +889,6 @@ export function rowMenu(
       false,
     );
   } else {
-    if (row.hasSwitch && !hasOff && row.deployment) {
-      push(
-        {
-          label: `Disable for ${row.harnessLabel}`,
-          action: { kind: "set-enabled", deployment: row.deployment, enabled: false },
-        },
-        false,
-      );
-    }
     push(
       {
         label: "Reveal in Finder",
@@ -976,8 +949,6 @@ export function rowMenu(
   }
 
   let hint = row.conditions.find((c) => c.hint)?.hint;
-  if (row.kind === "reader" && !row.hasSwitch)
-    hint = `Always on. ${row.harnessLabel} has no per-skill switch.`;
   if (row.kind === "plugin" && row.deployment?.plugin) {
     hint = `Managed by the ${row.deployment.plugin.name} plugin. Disable it in ${row.harnessLabel}.`;
   }

--- a/apps/desktop/src/components/ui/MaterializeRootDialog.tsx
+++ b/apps/desktop/src/components/ui/MaterializeRootDialog.tsx
@@ -65,7 +65,7 @@ export function MaterializeRootDialog({
             intent.kind === "convert-then-disable"
               ? "Couldn't convert and turn off"
               : "Couldn't convert",
-          message: err instanceof Error ? err.message : "Unknown error",
+          message: err instanceof Error ? err.message : String(err),
         });
       })
       .finally(() => setIsConverting(false));

--- a/apps/desktop/src/hooks/useSkillSnapshot.test.ts
+++ b/apps/desktop/src/hooks/useSkillSnapshot.test.ts
@@ -40,6 +40,7 @@ describe("selectNewerSkillSnapshot", () => {
 describe("startSkillSnapshotSubscription", () => {
   it("registers before reading and rejects a stale initial read", async () => {
     let current: SkillSnapshot | undefined;
+    const received: Array<{ revision: number; source: string }> = [];
     let listener: ((snapshot: SkillSnapshot) => void) | undefined;
     let finishRead: ((snapshot: SkillSnapshot) => void) | undefined;
     const read = new Promise<SkillSnapshot>((resolve) => {
@@ -52,7 +53,8 @@ describe("startSkillSnapshotSubscription", () => {
         return () => undefined;
       },
       read: () => read,
-      onSnapshot: (candidate) => {
+      onSnapshot: (candidate, source) => {
+        received.push({ revision: candidate.revision, source });
         current = selectNewerSkillSnapshot(current, candidate);
       },
       onError: () => undefined,
@@ -64,6 +66,10 @@ describe("startSkillSnapshotSubscription", () => {
     await subscription;
 
     expect(current?.scanned_at).toBe("event");
+    expect(received).toEqual([
+      { revision: 2, source: "event" },
+      { revision: 1, source: "initial" },
+    ]);
   });
 
   it("disposes a listener that finishes registering after unmount", async () => {

--- a/apps/desktop/src/hooks/useSkillSnapshot.ts
+++ b/apps/desktop/src/hooks/useSkillSnapshot.ts
@@ -3,7 +3,7 @@
 // Subscribes to the background refresh thread's skill snapshot
 // ============================================================================
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getSkillSnapshot, onSkillSnapshot, requestSkillRescan } from "../lib/skill-api";
 import type { SkillSnapshot } from "@skill-studio/lib";
 
@@ -21,7 +21,7 @@ interface SkillSnapshotSubscription {
   isCancelled: () => boolean;
   listen: typeof onSkillSnapshot;
   read: typeof getSkillSnapshot;
-  onSnapshot: (snapshot: SkillSnapshot) => void;
+  onSnapshot: (snapshot: SkillSnapshot, source: "initial" | "event") => void;
   onError: (message: string) => void;
   onSettled: () => void;
 }
@@ -38,7 +38,7 @@ export async function startSkillSnapshotSubscription({
   let unlisten: (() => void) | undefined;
   try {
     unlisten = await listen((candidate) => {
-      if (!isCancelled()) onSnapshot(candidate);
+      if (!isCancelled()) onSnapshot(candidate, "event");
     });
     if (isCancelled()) {
       unlisten();
@@ -49,7 +49,7 @@ export async function startSkillSnapshotSubscription({
       unlisten();
       return undefined;
     }
-    if (initial) onSnapshot(initial);
+    if (initial) onSnapshot(initial, "initial");
     return unlisten;
   } catch (error) {
     unlisten?.();
@@ -64,6 +64,8 @@ export async function startSkillSnapshotSubscription({
 
 interface UseSkillSnapshotResult {
   snapshot: SkillSnapshot | undefined;
+  /** Latest backend revision received through `skills://snapshot`, excluding the initial read. */
+  emittedSnapshotRevision: number | undefined;
   isLoading: boolean;
   error: string | null;
   /** Ask the background refresh thread to rebuild; resolves once the request lands, not once the new snapshot arrives. */
@@ -77,16 +79,22 @@ interface UseSkillSnapshotResult {
  */
 export function useSkillSnapshot(): UseSkillSnapshotResult {
   const [snapshot, setSnapshot] = useState<SkillSnapshot | undefined>(undefined);
+  const [emittedSnapshotRevision, setEmittedSnapshotRevision] = useState<number | undefined>(
+    undefined,
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | undefined;
+    isMountedRef.current = true;
 
-    const applySnapshot = (candidate: SkillSnapshot | undefined) => {
-      if (!cancelled && candidate) {
+    const applySnapshot = (candidate: SkillSnapshot, source: "initial" | "event") => {
+      if (!cancelled) {
         setSnapshot((current) => selectNewerSkillSnapshot(current, candidate));
+        if (source === "event") setEmittedSnapshotRevision(candidate.revision);
         setIsLoading(false);
       }
     };
@@ -108,6 +116,7 @@ export function useSkillSnapshot(): UseSkillSnapshotResult {
 
     return () => {
       cancelled = true;
+      isMountedRef.current = false;
       unlisten?.();
     };
   }, []);
@@ -116,9 +125,12 @@ export function useSkillSnapshot(): UseSkillSnapshotResult {
     try {
       await requestSkillRescan();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to request rescan");
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : "Failed to request rescan");
+      }
+      throw err;
     }
   };
 
-  return { snapshot, isLoading, error, requestRescan };
+  return { snapshot, emittedSnapshotRevision, isLoading, error, requestRescan };
 }

--- a/apps/desktop/src/lib/sidebar-nav.ts
+++ b/apps/desktop/src/lib/sidebar-nav.ts
@@ -16,13 +16,28 @@ export function sidebarAnchorView(activeView: ActiveView): ActiveView {
 }
 
 export function relativeScanTime(scannedAt: string | undefined): string {
-  if (!scannedAt) return "never scanned";
+  if (!scannedAt) return "Never";
   const ms = Date.now() - new Date(scannedAt).getTime();
-  if (ms < 0 || Number.isNaN(ms)) return "just now";
+  if (ms < 0 || Number.isNaN(ms)) return "Just now";
   const minutes = Math.floor(ms / 60_000);
-  if (minutes < 1) return "just now";
+  if (minutes < 1) return "Just now";
   if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;
   return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function rescanTooltip(scannedAt: string | undefined): string {
+  return `Refresh skills from disk\nLast sync: ${relativeScanTime(scannedAt)}`;
+}
+
+/** A manual sync completes only on a later listener-delivered backend revision. */
+export function hasNewerSkillSnapshotEmission(
+  requestedSnapshotRevision: number | undefined,
+  emittedSnapshotRevision: number | undefined,
+): boolean {
+  return (
+    emittedSnapshotRevision !== undefined &&
+    (requestedSnapshotRevision === undefined || emittedSnapshotRevision > requestedSnapshotRevision)
+  );
 }


### PR DESCRIPTION
The sidebar Sync button now stays busy until a newer snapshot event arrives, clears on a failed request, and puts the last-sync time in its tooltip. Initial snapshot reads cannot end a pending sync.

Location rows use one switch for visibility instead of repeating Disable in the menu. Readers without a per-skill switch show a disabled control that also reflects a parked skill. Styled inputs retain their own focus border while raw fields keep the global outline. Backend string errors remain visible in the conversion dialog, and remaining destination errors use Universal-folder terminology.

Based on #49. This carries only the local UI and error-message changes that its newer lifecycle implementation did not include; it preserves exact deployment targets and snapshot ordering. Typecheck, scoped lint, 52 frontend tests, and the Rust suite passed. The parked-reader regression checks the rendered switch and accessible label.
