### PR TITLE
fix: resolve remaining skill UI findings

### DIFF
--- a/apps/desktop/src/components/Settings/SettingsView.tsx
+++ b/apps/desktop/src/components/Settings/SettingsView.tsx
@@ -17,6 +17,7 @@ import {
   type EditorOption,
 } from "../../lib/skill-api";
 import { useAppStore } from "../../store/appStore";
+import { skillsShAccessStatusText, type SkillsShAccessState } from "./skills-sh-access-status";
 
 /** The always-available first choice: the first installed editor Skill Studio knows about. */
 function automaticOption(editors: EditorOption[]) {
@@ -120,11 +121,7 @@ function EditorPicker() {
  */
 function SkillsShKeySetting() {
   const addToast = useAppStore((state) => state.addToast);
-  const [access, setAccess] = useState<{ mode: "direct" | "server"; server_url: string | null }>({
-    mode: "server",
-    server_url: null,
-  });
-  const [isLoading, setIsLoading] = useState(true);
+  const [accessState, setAccessState] = useState<SkillsShAccessState>({ kind: "loading" });
   const [key, setKey] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
@@ -132,17 +129,15 @@ function SkillsShKeySetting() {
     let cancelled = false;
     getSkillsShAccess()
       .then((status) => {
-        if (!cancelled) setAccess(status);
+        if (!cancelled) setAccessState({ kind: "available", access: status });
       })
       .catch((err) => {
+        if (!cancelled) setAccessState({ kind: "unavailable" });
         addToast({
           type: "error",
           title: "Couldn't read your skills.sh access mode",
           message: err instanceof Error ? err.message : "Unknown error",
         });
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
       });
     return () => {
       cancelled = true;
@@ -153,7 +148,10 @@ function SkillsShKeySetting() {
     setIsSaving(true);
     setSkillsShApiKey(key)
       .then(() => {
-        setAccess({ mode: "direct", server_url: null });
+        setAccessState({
+          kind: "available",
+          access: { mode: "direct", server_url: null },
+        });
         setKey("");
       })
       .catch((err) => {
@@ -165,6 +163,8 @@ function SkillsShKeySetting() {
       })
       .finally(() => setIsSaving(false));
   };
+
+  const accessStatus = skillsShAccessStatusText(accessState);
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-border-subtle p-4">
@@ -189,13 +189,7 @@ function SkillsShKeySetting() {
           Save
         </Button>
       </div>
-      {!isLoading && (
-        <p className="m-0 text-small text-text-tertiary">
-          {access.mode === "direct"
-            ? "Using a local skills.sh key (developer override)"
-            : `Browsing through the Skill Studio server at ${access.server_url}`}
-        </p>
-      )}
+      {accessStatus && <p className="m-0 text-small text-text-tertiary">{accessStatus}</p>}
     </div>
   );
 }

--- a/apps/desktop/src/components/Settings/skills-sh-access-status.test.ts
+++ b/apps/desktop/src/components/Settings/skills-sh-access-status.test.ts
@@ -1,0 +1,42 @@
+// ============================================================================
+// Skill Studio - skills.sh access status tests
+// ============================================================================
+
+import { describe, expect, it } from "vitest";
+import { skillsShAccessStatusText } from "./skills-sh-access-status";
+
+describe("skillsShAccessStatusText", () => {
+  it("shows no authoritative status while loading", () => {
+    expect(skillsShAccessStatusText({ kind: "loading" })).toBeNull();
+  });
+
+  it("shows an explicit unavailable state after a failed read", () => {
+    expect(skillsShAccessStatusText({ kind: "unavailable" })).toBe(
+      "skills.sh access status is unavailable.",
+    );
+  });
+
+  it("keeps successful direct and server copy unchanged", () => {
+    expect(
+      skillsShAccessStatusText({
+        kind: "available",
+        access: { mode: "direct", server_url: null },
+      }),
+    ).toBe("Using a local skills.sh key (developer override)");
+    expect(
+      skillsShAccessStatusText({
+        kind: "available",
+        access: { mode: "server", server_url: "http://127.0.0.1:8787/api/v1" },
+      }),
+    ).toBe("Browsing through the Skill Studio server at http://127.0.0.1:8787/api/v1");
+  });
+
+  it("never formats an invalid server response as at null", () => {
+    expect(
+      skillsShAccessStatusText({
+        kind: "available",
+        access: { mode: "server", server_url: null },
+      }),
+    ).toBe("skills.sh access status is unavailable.");
+  });
+});

--- a/apps/desktop/src/components/Settings/skills-sh-access-status.ts
+++ b/apps/desktop/src/components/Settings/skills-sh-access-status.ts
@@ -1,0 +1,23 @@
+// ============================================================================
+// Skill Studio - skills.sh access status
+// Models whether Settings has authoritative direct/server access information.
+// ============================================================================
+
+import type { SkillsShAccessInfo } from "@skill-studio/lib";
+
+export type SkillsShAccessState =
+  | { kind: "loading" }
+  | { kind: "available"; access: SkillsShAccessInfo }
+  | { kind: "unavailable" };
+
+/** Returns Settings status copy only when loading has finished. */
+export function skillsShAccessStatusText(state: SkillsShAccessState): string | null {
+  if (state.kind === "loading") return null;
+  if (state.kind === "unavailable") return "skills.sh access status is unavailable.";
+  if (state.access.mode === "direct") {
+    return "Using a local skills.sh key (developer override)";
+  }
+  return state.access.server_url
+    ? `Browsing through the Skill Studio server at ${state.access.server_url}`
+    : "skills.sh access status is unavailable.";
+}

--- a/apps/desktop/src/components/SkillDetail/SkillAgentTranscript.test.ts
+++ b/apps/desktop/src/components/SkillDetail/SkillAgentTranscript.test.ts
@@ -1,0 +1,63 @@
+// ============================================================================
+// Skill Studio - skill agent transcript state tests
+// ============================================================================
+
+import { describe, expect, it } from "vitest";
+import type { SkillAgentRunState } from "../../hooks/useSkillAgentRun";
+import {
+  skillAgentRunHasTranscript,
+  skillAgentRunTerminalLabel,
+  unreportedSkillAgentRunError,
+} from "./skill-agent-transcript-policy";
+
+function fixtureRunState(overrides: Partial<SkillAgentRunState> = {}): SkillAgentRunState {
+  return {
+    status: "idle",
+    runId: undefined,
+    events: [],
+    finalText: undefined,
+    sessionId: undefined,
+    costUsd: undefined,
+    durationMs: undefined,
+    skillLoaded: undefined,
+    errorMessage: undefined,
+    ...overrides,
+  };
+}
+
+describe("Assistant run errors", () => {
+  it("shows a harness start failure even when no event was streamed", () => {
+    const state = fixtureRunState({
+      status: "error",
+      runId: "run-1",
+      errorMessage: "Claude Code executable was not found",
+    });
+
+    expect(skillAgentRunHasTranscript(state)).toBe(true);
+    expect(unreportedSkillAgentRunError(state)).toBe("Claude Code executable was not found");
+  });
+
+  it("does not duplicate an error already present in the streamed transcript", () => {
+    const state = fixtureRunState({
+      status: "error",
+      errorMessage: "Run failed",
+      events: [
+        {
+          run_id: "run-1",
+          seq: 1,
+          at: "2026-01-01T00:00:00Z",
+          kind: { kind: "error", message: "Run failed" },
+        },
+      ],
+    });
+
+    expect(unreportedSkillAgentRunError(state)).toBeUndefined();
+  });
+});
+
+describe("Assistant terminal footer", () => {
+  it("distinguishes failed runs from finished runs", () => {
+    expect(skillAgentRunTerminalLabel("error")).toBe("Failed");
+    expect(skillAgentRunTerminalLabel("finished")).toBe("Finished");
+  });
+});

--- a/apps/desktop/src/components/SkillDetail/SkillAgentTranscript.tsx
+++ b/apps/desktop/src/components/SkillDetail/SkillAgentTranscript.tsx
@@ -9,6 +9,10 @@ import { useEffect, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "@skill-studio/ui";
 import { SkillMarkdown } from "./SkillMarkdown";
+import {
+  skillAgentRunTerminalLabel,
+  unreportedSkillAgentRunError,
+} from "./skill-agent-transcript-policy";
 import type { SkillAgentRunState } from "../../hooks/useSkillAgentRun";
 import type { SkillAgentEvent, SkillLoaded } from "@skill-studio/lib";
 
@@ -66,7 +70,8 @@ const SKILL_LOADED_LABEL = {
 
 /** Footer segments before "skill loaded: …", e.g. ["Finished", "4.2 s", "$0.06"]. Omits parts the run didn't report. */
 function footerLeadSegments(state: SkillAgentRunState): string[] {
-  const segments = ["Finished"];
+  const terminalLabel = skillAgentRunTerminalLabel(state.status);
+  const segments = terminalLabel ? [terminalLabel] : [];
   if (state.durationMs !== undefined) segments.push(`${(state.durationMs / 1000).toFixed(1)} s`);
   if (state.costUsd !== undefined) segments.push(`$${state.costUsd.toFixed(2)}`);
   return segments;
@@ -109,6 +114,7 @@ function ToolCallBlock({ block }: { block: Extract<TranscriptBlock, { kind: "too
  */
 export function SkillAgentTranscript({ state }: SkillAgentTranscriptProps) {
   const blocks = buildBlocks(state.events);
+  const unreportedError = unreportedSkillAgentRunError(state);
   const scrollRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
 
@@ -138,6 +144,12 @@ export function SkillAgentTranscript({ state }: SkillAgentTranscriptProps) {
       ref={scrollRef}
       onScroll={handleScroll}
     >
+      {unreportedError && (
+        <div className="rounded-sm bg-error-soft px-2.5 py-2 text-small break-words whitespace-pre-wrap text-error">
+          {unreportedError}
+        </div>
+      )}
+
       {blocks.map((block) => {
         if (block.kind === "text") {
           return <SkillMarkdown key={block.id} content={block.text} className="leading-normal" />;

--- a/apps/desktop/src/components/SkillDetail/SkillAssistantPanel.tsx
+++ b/apps/desktop/src/components/SkillDetail/SkillAssistantPanel.tsx
@@ -22,7 +22,6 @@ import {
   parseJudgeVerdict,
 } from "@skill-studio/lib";
 import type { HarnessId } from "@skill-studio/lib";
-import { skillVisibleToAgent } from "@skill-studio/lib";
 import type { SkillMdHunk } from "@skill-studio/lib";
 import { diffSkillMd } from "@skill-studio/lib";
 import { ownDeployments, ownSkillsView } from "@skill-studio/lib";
@@ -36,33 +35,20 @@ import {
   skillRunTargetDiff,
 } from "../../lib/skill-run-target-api";
 import type { SkillRunTargetInfo } from "@skill-studio/lib";
-import { COMMON_AGENTS } from "@skill-studio/lib";
-import type { AgentId, InstalledSkill, Toast } from "@skill-studio/lib";
+import type { InstalledSkill, Toast } from "@skill-studio/lib";
 import { useAppStore } from "../../store/appStore";
 import { HarnessIcon } from "../ui/HarnessIcon";
 import { HARNESS_LABELS } from "../../lib/harness-labels";
-import type { SelectControlItem } from "../ui/SelectControl";
 import { SelectControl } from "../ui/SelectControl";
 import { SkillAgentTranscript } from "./SkillAgentTranscript";
+import { skillAgentRunHasTranscript } from "./skill-agent-transcript-policy";
+import {
+  isSkillAssistantHarness,
+  skillAssistantHarnessPolicy,
+} from "./skill-assistant-harness-policy";
 import { SkillRunHistory } from "./SkillRunHistory";
 import type { SkillTestRunParams } from "./SkillTestForm";
 import { SkillTestForm } from "./SkillTestForm";
-
-/**
- * `HARNESS_LABELS` as `SelectControl` items, for the assistant panel's
- * harness picker. A run doesn't use the installed copy - it copies the skill
- * into a fresh scratch folder (see `sourceFolderPath`) and runs there - so a
- * harness with no deployment for `skill` still runs normally. The label
- * still says so, since `visibleAgentsFor` is useful context, but the item
- * stays selectable: disabling it would leave a dead end when no harness sees
- * the skill (`defaultHarness` falls back to Claude Code either way).
- */
-function harnessSelectItems(visibleAgents: readonly AgentId[]): SelectControlItem[] {
-  return HARNESS_LABELS.map(([value, label]) => ({
-    value,
-    label: visibleAgents.includes(value) ? label : `${label} (doesn't see this skill)`,
-  }));
-}
 
 interface SkillAssistantPanelProps {
   skill: InstalledSkill;
@@ -178,11 +164,6 @@ function runSessionReducer(state: RunSessionState, action: RunSessionAction): Ru
   }
 }
 
-/** Every first-class agent that can actually see `skill`, in `COMMON_AGENTS` order. */
-function visibleAgentsFor(skill: InstalledSkill): AgentId[] {
-  return COMMON_AGENTS.filter((agent) => skillVisibleToAgent(skill, agent) !== "none");
-}
-
 /** `skill`'s own skill folder, for the scratch dir - a plugin-only skill has no folder to copy. */
 function sourceFolderPath(skill: InstalledSkill): string | undefined {
   return ownDeployments(skill)[0]?.path ?? skill.deployments[0]?.path;
@@ -223,7 +204,7 @@ function buildRunRecord(
 interface UseAssistantRunSessionParams {
   skill: InstalledSkill;
   skillMdPath: string | undefined;
-  defaultHarness: AgentId;
+  defaultHarness: HarnessId;
   cancel: () => Promise<void>;
   judgeCancel: () => Promise<void>;
   reset: () => Promise<void>;
@@ -249,7 +230,7 @@ function useAssistantRunSession({
   judgeReset,
   addToast,
 }: UseAssistantRunSessionParams) {
-  const [harness, setHarness] = useState<AgentId>(defaultHarness);
+  const [harness, setHarness] = useState<HarnessId>(defaultHarness);
   const [scratchDir, setScratchDir] = useState<string | undefined>(undefined);
   const [isPreparing, setIsPreparing] = useState(false);
   const [showTestForm, setShowTestForm] = useState(false);
@@ -347,7 +328,7 @@ function useAssistantRunSession({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleSelectHarness = async (agent: AgentId) => {
+  const handleSelectHarness = async (agent: HarnessId) => {
     if (agent === harness) return;
     const token = ++opTokenRef.current;
     // Stop the previous harness's run before switching out from under it.
@@ -650,7 +631,7 @@ interface UseAssistantActionsParams {
   rawContent: string | null;
   skillMdPath: string | undefined;
   isPluginManaged: boolean;
-  harness: AgentId;
+  harness: HarnessId;
   prompt: string;
   state: SkillAgentRunState;
   run: (request: Parameters<ReturnType<typeof useSkillAgentRun>["run"]>[0]) => Promise<void>;
@@ -703,10 +684,8 @@ function useAssistantActions({
     dispatchRunSession({ type: "set_run_kind", kind: "ask" });
     recordedRunIdRef.current = undefined;
     try {
-      // SAFETY: `harness` only ever holds a value from `HarnessSegmentedControl`,
-      // which offers exactly the four `HarnessId` agents.
       await run({
-        harness: harness as HarnessId,
+        harness,
         prompt,
         cwd: dir,
         skill_name: skill.name,
@@ -733,10 +712,8 @@ function useAssistantActions({
     dispatchRunSession({ type: "start_audit" });
     recordedRunIdRef.current = undefined;
     try {
-      // SAFETY: `harness` only ever holds a value from `HarnessSegmentedControl`,
-      // which offers exactly the four `HarnessId` agents.
       await run({
-        harness: harness as HarnessId,
+        harness,
         prompt: buildSkillAuditPrompt({
           skillName: skill.name,
           skillMd: rawContent,
@@ -784,14 +761,12 @@ function useAssistantActions({
     activeTargetRef.current = null;
     dispatchRunSession({ type: "start_test" });
 
-    // SAFETY: `harness` only ever holds a value from `HarnessSegmentedControl`,
-    // which offers exactly the four `HarnessId` agents.
     await runSkillTestFlow({
       skill,
       params,
       sourcePath,
       extraSkills,
-      harness: harness as HarnessId,
+      harness,
       token,
       opTokenRef,
       setActiveTarget,
@@ -810,7 +785,7 @@ interface TestJudgePanelProps {
   judgeState: SkillAgentRunState;
   runState: SkillAgentRunState;
   verdict: ReturnType<typeof parseJudgeVerdict>;
-  harness: AgentId;
+  harness: HarnessId;
 }
 
 /** The "Test" run's judge transcript and pass/fail verdict, shown once the
@@ -945,10 +920,7 @@ export function SkillAssistantPanel({
 }: SkillAssistantPanelProps) {
   const addToast = useAppStore((state) => state.addToast);
   const { snapshot } = useSkillSnapshot();
-  const visibleAgents = visibleAgentsFor(skill);
-  const defaultHarness: AgentId =
-    (visibleAgents.includes("claude-code") ? "claude-code" : visibleAgents[0]) ?? "claude-code";
-  const harnessSelectItemsForSkill = harnessSelectItems(visibleAgents);
+  const { defaultHarness, items: harnessSelectItemsForSkill } = skillAssistantHarnessPolicy(skill);
 
   const [prompt, setPrompt] = useState("");
   // The file's content at the moment the current audit run started, so a
@@ -1060,9 +1032,7 @@ export function SkillAssistantPanel({
     if (!state.runId || recordedRunIdRef.current === state.runId) return;
     recordedRunIdRef.current = state.runId;
     recordSkillRun(
-      // SAFETY: `harness` only ever holds a value from `HarnessSegmentedControl`,
-      // which offers exactly the four `HarnessId` agents.
-      buildRunRecord(state, harness as HarnessId, skill.name, runKind, undefined, undefined),
+      buildRunRecord(state, harness, skill.name, runKind, undefined, undefined),
       state.events,
     ).catch(() => {});
   }, [runKind, state, skill.name, harness]);
@@ -1084,7 +1054,7 @@ export function SkillAssistantPanel({
     });
 
   const isRunning = state.status === "running" || isPreparing;
-  const hasTranscript = state.events.length > 0;
+  const hasTranscript = skillAgentRunHasTranscript(state);
   const canAudit = rawContent !== null && !isPluginManaged && !isRunning;
   const candidateProjects = testCandidateProjects(skill, snapshot?.projects ?? []);
   const isTestRunning =
@@ -1100,8 +1070,7 @@ export function SkillAssistantPanel({
         ariaLabel="Harness"
         value={harness}
         onValueChange={(value) => {
-          // SAFETY: `items` only ever holds a value from `HARNESS_LABELS`.
-          handleSelectHarness(value as AgentId);
+          if (isSkillAssistantHarness(value)) handleSelectHarness(value);
         }}
         items={harnessSelectItemsForSkill}
         leadingIcon={<HarnessIcon harness={harness} size={14} />}

--- a/apps/desktop/src/components/SkillDetail/SkillPage.tsx
+++ b/apps/desktop/src/components/SkillDetail/SkillPage.tsx
@@ -28,6 +28,7 @@ import { DiscardChangesDialog } from "./DiscardChangesDialog";
 import { InstalledSkillHeader } from "./InstalledSkillHeader";
 import { SkillAssistantDrawer } from "./SkillAssistantDrawer";
 import { SkillAssistantPanel } from "./SkillAssistantPanel";
+import { useSkillAssistantNavigation } from "./skill-assistant-view-policy";
 import { SkillCompareDialog } from "./SkillCompareDialog";
 import { SkillFrontmatterRepairDialog } from "./SkillFrontmatterRepairDialog";
 import { SkillLocationsCard } from "./SkillLocationsCard";
@@ -196,9 +197,10 @@ export function SkillPage({
   const clearSkillIntent = useAppStore((state) => state.clearSkillIntent);
   const isAssistantOpen = useAppStore((state) => state.isAssistantOpen);
   const setIsAssistantOpen = useAppStore((state) => state.setIsAssistantOpen);
+  const { isRunsOpen, openAssistant, closeAssistant, openRuns, closeRuns } =
+    useSkillAssistantNavigation(skill?.name, setIsAssistantOpen);
   const [isEditing, setIsEditing] = useState(false);
   const [isEditorDirty, setIsEditorDirty] = useState(false);
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [isCompareOpen, setIsCompareOpen] = useState(false);
   const [frontmatterRepair, setFrontmatterRepair] = useState<FrontmatterRepairPreview | null>(null);
   const [isFrontmatterRepairOpen, setIsFrontmatterRepairOpen] = useState(false);
@@ -266,14 +268,6 @@ export function SkillPage({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
 
-  /** The skill the history drawer was last shown for, so a skill switch closes it instead of carrying it over. */
-  const historySkillNameRef = useRef<string | undefined>(skill?.name);
-  if (historySkillNameRef.current !== skill?.name) {
-    // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- adjust-during-render, per React docs "storing information from previous renders"
-    historySkillNameRef.current = skill?.name;
-    if (isHistoryOpen) setIsHistoryOpen(false);
-  }
-
   // The deployment this page edits: only the one the caller clicked, when
   // given - a stale `deploymentPath` (the copy was removed by a rescan) must
   // not silently fall back to a different copy of the skill. With no
@@ -326,7 +320,7 @@ export function SkillPage({
 
   // A skill switch can't carry over a draft or edit mode from a different
   // skill - adjusted during render (same single-ref pattern as
-  // `compareSkillNameRef`/`historySkillNameRef` above), keyed off the same
+  // `compareSkillNameRef` above), keyed off the same
   // identity `useSkillMdContent`'s own reset uses.
   const editSkillNameRef = useRef<string | undefined>(skill?.name);
   if (editSkillNameRef.current !== skill?.name) {
@@ -381,7 +375,7 @@ export function SkillPage({
         onBack={onBack}
         onRemoveComplete={onRemoveComplete}
         isAssistantOpen={isAssistantOpen}
-        onOpenAssistant={() => setIsAssistantOpen(true)}
+        onOpenAssistant={openAssistant}
         assistantTriggerRef={assistantTriggerRef}
         frontmatterRepair={selectedFrontmatterRepair}
         onFixYaml={() => setIsFrontmatterRepairOpen(true)}
@@ -424,7 +418,7 @@ export function SkillPage({
 
       <SkillAssistantDrawer
         isOpen={isAssistantOpen && isFeatureEnabled("skill-assistant")}
-        onClose={() => setIsAssistantOpen(false)}
+        onClose={closeAssistant}
         triggerRef={assistantTriggerRef}
       >
         <SkillAssistantPanel
@@ -436,9 +430,9 @@ export function SkillPage({
           onDiskChanged={() => {
             if (skillMdPath) loadContent(skillMdPath, false);
           }}
-          showHistory={isHistoryOpen}
-          onOpenHistory={() => setIsHistoryOpen(true)}
-          onCloseHistory={() => setIsHistoryOpen(false)}
+          showHistory={isRunsOpen}
+          onOpenHistory={openRuns}
+          onCloseHistory={closeRuns}
         />
       </SkillAssistantDrawer>
 

--- a/apps/desktop/src/components/SkillDetail/skill-agent-transcript-policy.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-agent-transcript-policy.ts
@@ -1,0 +1,27 @@
+// ============================================================================
+// Skill Studio - skill agent transcript policy
+// Includes run-start errors that arrive before the event stream begins.
+// ============================================================================
+
+import type { SkillAgentRunState, SkillAgentRunStatus } from "../../hooks/useSkillAgentRun";
+
+/** Returns the terminal transcript label for a completed or failed skill agent run. */
+export function skillAgentRunTerminalLabel(status: SkillAgentRunStatus): string | undefined {
+  if (status === "error") return "Failed";
+  if (status === "finished") return "Finished";
+  return undefined;
+}
+
+/** Whether a run has transcript content or a start failure that the Assistant must show. */
+export function skillAgentRunHasTranscript(state: SkillAgentRunState): boolean {
+  return state.events.length > 0 || state.errorMessage !== undefined;
+}
+
+/** Returns a run error only when no streamed error event already reports the same message. */
+export function unreportedSkillAgentRunError(state: SkillAgentRunState): string | undefined {
+  if (!state.errorMessage) return undefined;
+  const hasMatchingEvent = state.events.some(
+    (event) => event.kind.kind === "error" && event.kind.message === state.errorMessage,
+  );
+  return hasMatchingEvent ? undefined : state.errorMessage;
+}

--- a/apps/desktop/src/components/SkillDetail/skill-assistant-harness-policy.test.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-assistant-harness-policy.test.ts
@@ -1,0 +1,102 @@
+// ============================================================================
+// Skill Studio - assistant harness policy tests
+// ============================================================================
+
+import { describe, expect, it } from "vitest";
+import type { Deployment, InstalledSkill } from "@skill-studio/lib";
+import {
+  isSkillAssistantHarness,
+  skillAssistantHarnessPolicy,
+} from "./skill-assistant-harness-policy";
+
+function fixtureDeployment(overrides: Partial<Deployment> = {}): Deployment {
+  return {
+    id: "dep:v1/global/universal/find-bugs",
+    destination: "universal",
+    owner_kind: "manual",
+    mutability: "mutable",
+    backing: { kind: "canonical" },
+    agent: "shared",
+    scope: "global",
+    path: "/home/.agents/skills/find-bugs",
+    is_symlink: false,
+    symlink_is_broken: false,
+    content_hash: "abc",
+    disabled: false,
+    ...overrides,
+  };
+}
+
+function fixtureSkill(deployments: Deployment[]): InstalledSkill {
+  return {
+    name: "find-bugs",
+    source: "getsentry/find-bugs",
+    source_type: "github",
+    installed_at: "2026-01-01T00:00:00Z",
+    has_update: false,
+    source_kind: "dotagents",
+    deployments,
+    has_spec: false,
+    spec_violations: [],
+    skill_md_tokens: 0,
+    description_tokens: 0,
+    folder_bytes: 0,
+    file_count: 0,
+    content_hash: "",
+    content_hashes: [],
+    frontmatter_fields: {},
+    folder_truncated: false,
+    parked: false,
+    invocation: "both",
+    update_owner_ids: [],
+  };
+}
+
+describe("skillAssistantHarnessPolicy", () => {
+  it("marks a disabled shared-root reader as not seeing the skill", () => {
+    const policy = skillAssistantHarnessPolicy(
+      fixtureSkill([fixtureDeployment({ disabled_readers: ["open-code"] })]),
+    );
+
+    expect(policy.defaultHarness).toBe("codex");
+    expect(policy.items).toContainEqual({
+      value: "open-code",
+      label: "OpenCode (doesn't see this skill)",
+    });
+    expect(policy.items).toContainEqual({ value: "codex", label: "Codex" });
+  });
+
+  it("keeps a supported healthy own deployment visible when the shared reader is disabled", () => {
+    const policy = skillAssistantHarnessPolicy(
+      fixtureSkill([
+        fixtureDeployment({ disabled_readers: ["codex", "open-code", "pi"] }),
+        fixtureDeployment({
+          agent: "OpenCode",
+          path: "/home/.config/opencode/skills/find-bugs",
+        }),
+      ]),
+    );
+
+    expect(policy.defaultHarness).toBe("open-code");
+    expect(policy.items).toContainEqual({ value: "open-code", label: "OpenCode" });
+  });
+
+  it("falls back to Claude Code without offering a Cursor-only deployment as runnable", () => {
+    const policy = skillAssistantHarnessPolicy(
+      fixtureSkill([
+        fixtureDeployment({ agent: "Cursor", path: "/home/.cursor/skills/find-bugs" }),
+      ]),
+    );
+
+    expect(policy.defaultHarness).toBe("claude-code");
+    expect(policy.items.map((item) => item.value)).toEqual([
+      "claude-code",
+      "codex",
+      "open-code",
+      "pi",
+    ]);
+    expect(policy.items[0]?.label).toBe("Claude Code (doesn't see this skill)");
+    expect(isSkillAssistantHarness("cursor")).toBe(false);
+    expect(isSkillAssistantHarness(policy.defaultHarness)).toBe(true);
+  });
+});

--- a/apps/desktop/src/components/SkillDetail/skill-assistant-harness-policy.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-assistant-harness-policy.ts
@@ -1,0 +1,38 @@
+// ============================================================================
+// Skill Studio - assistant harness policy
+// Keeps the Assistant runner limited to backend-supported harnesses while
+// reporting whether each harness can see the installed skill.
+// ============================================================================
+
+import { skillVisibleToAgent } from "@skill-studio/lib";
+import type { HarnessId, InstalledSkill } from "@skill-studio/lib";
+import { HARNESS_LABELS } from "../../lib/harness-labels";
+
+export interface SkillAssistantHarnessPolicy {
+  defaultHarness: HarnessId;
+  items: { value: HarnessId; label: string }[];
+}
+
+/** Builds supported Assistant choices and a truthful default for one installed skill. */
+export function skillAssistantHarnessPolicy(skill: InstalledSkill): SkillAssistantHarnessPolicy {
+  const visibleHarnesses = new Set<HarnessId>();
+  const items = HARNESS_LABELS.map(([value, label]) => {
+    const isVisible = skillVisibleToAgent(skill, value) !== "none";
+    if (isVisible) visibleHarnesses.add(value);
+    return {
+      value,
+      label: isVisible ? label : `${label} (doesn't see this skill)`,
+    };
+  });
+
+  const defaultHarness = visibleHarnesses.has("claude-code")
+    ? "claude-code"
+    : (HARNESS_LABELS.find(([value]) => visibleHarnesses.has(value))?.[0] ?? "claude-code");
+
+  return { defaultHarness, items };
+}
+
+/** Narrows a select-control value to a harness supported by the Assistant backend. */
+export function isSkillAssistantHarness(value: string): value is HarnessId {
+  return HARNESS_LABELS.some(([harness]) => harness === value);
+}

--- a/apps/desktop/src/components/SkillDetail/skill-assistant-view-policy.test.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-assistant-view-policy.test.ts
@@ -1,0 +1,18 @@
+// ============================================================================
+// Skill Studio - Assistant view policy tests
+// ============================================================================
+
+import { describe, expect, it } from "vitest";
+import { nextSkillAssistantPanelMode } from "./skill-assistant-view-policy";
+
+describe("nextSkillAssistantPanelMode", () => {
+  it("resets Runs when the Assistant drawer closes or opens", () => {
+    expect(nextSkillAssistantPanelMode("runs", "close-assistant")).toBe("assistant");
+    expect(nextSkillAssistantPanelMode("runs", "open-assistant")).toBe("assistant");
+  });
+
+  it("opens Runs only for the explicit Runs action", () => {
+    expect(nextSkillAssistantPanelMode("assistant", "open-runs")).toBe("runs");
+    expect(nextSkillAssistantPanelMode("runs", "close-runs")).toBe("assistant");
+  });
+});

--- a/apps/desktop/src/components/SkillDetail/skill-assistant-view-policy.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-assistant-view-policy.ts
@@ -1,0 +1,67 @@
+// ============================================================================
+// Skill Studio - Assistant view policy
+// Controls whether the open Assistant drawer shows its main panel or Runs.
+// ============================================================================
+
+import { useState } from "react";
+
+export type SkillAssistantPanelMode = "assistant" | "runs";
+export type SkillAssistantPanelAction =
+  | "open-assistant"
+  | "close-assistant"
+  | "open-runs"
+  | "close-runs"
+  | "change-skill";
+
+/** Selects the Assistant panel mode after one drawer or Runs navigation action. */
+export function nextSkillAssistantPanelMode(
+  current: SkillAssistantPanelMode,
+  action: SkillAssistantPanelAction,
+): SkillAssistantPanelMode {
+  switch (action) {
+    case "open-runs":
+      return "runs";
+    case "open-assistant":
+    case "close-assistant":
+    case "close-runs":
+    case "change-skill":
+      return "assistant";
+    default:
+      return current;
+  }
+}
+
+/** Owns Assistant drawer and Runs navigation, resetting the nested view when its skill changes. */
+export function useSkillAssistantNavigation(
+  skillName: string | undefined,
+  setIsAssistantOpen: (isOpen: boolean) => void,
+) {
+  const [panelMode, setPanelMode] = useState<SkillAssistantPanelMode>("assistant");
+  const [previousSkillName, setPreviousSkillName] = useState(skillName);
+
+  if (previousSkillName !== skillName) {
+    // react-doctor-disable-next-line react-doctor/no-adjust-state-on-prop-change -- adjust-during-render, per React docs "storing information from previous renders"
+    setPreviousSkillName(skillName);
+    if (panelMode === "runs") {
+      setPanelMode((current) => nextSkillAssistantPanelMode(current, "change-skill"));
+    }
+  }
+
+  const transitionPanel = (action: SkillAssistantPanelAction) => {
+    setPanelMode((current) => nextSkillAssistantPanelMode(current, action));
+  };
+
+  return {
+    isRunsOpen: panelMode === "runs",
+    openAssistant: () => {
+      transitionPanel("open-assistant");
+      setIsAssistantOpen(true);
+    },
+    closeAssistant: () => {
+      transitionPanel("close-assistant");
+      setIsAssistantOpen(false);
+    },
+    openRuns: () => transitionPanel("open-runs"),
+    closeRuns: () => transitionPanel("close-runs"),
+  };
+}

--- a/apps/desktop/src/components/SkillDetail/skill-location-actions.test.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-location-actions.test.ts
@@ -25,15 +25,24 @@ function wholeRootDeployment(): Deployment {
 }
 
 describe("materializeRequestForLocationAction", () => {
-  it("routes an explicit conversion as convert-only", () => {
+  it.each([
+    ["claude-code", "Claude Code"],
+    ["open-code", "OpenCode"],
+  ] as const)("routes an explicit %s conversion with display label %s", (harness, harnessLabel) => {
     expect(
       materializeRequestForLocationAction({
         kind: "convert-root",
         target: { deployment_id: "deployment" },
-        harness: "claude-code",
+        harness,
         root: "/home/.claude/skills",
       }),
-    ).toMatchObject({ intent: "convert-only", root: "/home/.claude/skills" });
+    ).toEqual({
+      target: { deployment_id: "deployment" },
+      harness,
+      harnessLabel,
+      root: "/home/.claude/skills",
+      intent: "convert-only",
+    });
   });
 
   it("routes only whole-root toggle-off as convert-then-disable", () => {

--- a/apps/desktop/src/components/SkillDetail/skill-location-actions.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-location-actions.ts
@@ -9,7 +9,7 @@
 
 import { useState } from "react";
 import { agentIdFromDeploymentLabel, parseSkillSource } from "@skill-studio/lib";
-import type { Deployment, InstalledSkill, LifecycleTarget } from "@skill-studio/lib";
+import type { AgentId, Deployment, InstalledSkill, LifecycleTarget } from "@skill-studio/lib";
 import {
   addSkill,
   openSkillPath,
@@ -56,6 +56,26 @@ export interface MaterializeLocationRequest {
   intent: "convert-only" | "convert-then-disable";
 }
 
+/** Display label for a harness whose whole skills root can be materialized. */
+function materializeHarnessLabel(harness: AgentId): string {
+  switch (harness) {
+    case "claude-code":
+      return "Claude Code";
+    case "codex":
+      return "Codex";
+    case "open-code":
+      return "OpenCode";
+    case "pi":
+      return "pi";
+    case "cursor":
+      return "Cursor";
+    case "grok-build":
+      return "Grok Build";
+    default:
+      return harness;
+  }
+}
+
 /** Routes only explicit conversion and whole-root toggle-off actions to the conversion dialog. */
 export function materializeRequestForLocationAction(
   action: LocationAction,
@@ -64,7 +84,7 @@ export function materializeRequestForLocationAction(
     return {
       target: action.target,
       harness: action.harness,
-      harnessLabel: action.harness,
+      harnessLabel: materializeHarnessLabel(action.harness),
       root: action.root,
       intent: "convert-only",
     };

--- a/apps/desktop/src/components/SkillList/SkillListFilterBar.tsx
+++ b/apps/desktop/src/components/SkillList/SkillListFilterBar.tsx
@@ -64,9 +64,6 @@ interface SkillListFilterBarProps {
   showCoverage: boolean;
   onToggleCoverage: (show: boolean) => void;
   resultCount: number;
-  /** Free-text name/description filter, applied by `SkillListTable`. */
-  query: string;
-  onQueryChange: (query: string) => void;
   /** Sort order, applied by `SkillListTable`. */
   sort: SortMode;
   onSortChange: (sort: SortMode) => void;
@@ -129,8 +126,6 @@ export function SkillListFilterBar({
   showCoverage,
   onToggleCoverage,
   resultCount,
-  query,
-  onQueryChange,
   sort,
   onSortChange,
   snapshot,
@@ -161,8 +156,8 @@ export function SkillListFilterBar({
           <Search size={13} className="pointer-events-none absolute left-3" />
           <input
             className="h-(--control-height) w-full rounded-sm border border-border bg-bg-primary py-0 pr-3 pl-8 text-body text-text-primary transition-colors placeholder:text-text-quaternary focus-visible:border-border-focus"
-            value={query}
-            onChange={(e) => onQueryChange(e.target.value)}
+            value={filter.query}
+            onChange={(e) => onChange({ ...filter, query: e.target.value })}
             placeholder="Filter skills…"
             aria-label="Filter skills"
           />

--- a/apps/desktop/src/components/SkillList/SkillsView.tsx
+++ b/apps/desktop/src/components/SkillList/SkillsView.tsx
@@ -52,7 +52,6 @@ export function SkillsView({ snapshot, onSelectSkill }: SkillsViewProps) {
   const resetSkillListFilter = useAppStore((state) => state.resetSkillListFilter);
   const showCoverage = useAppStore((state) => state.showCoverage);
   const setShowCoverage = useAppStore((state) => state.setShowCoverage);
-  const [query, setQuery] = useState("");
   const [sort, setSort] = useState<SortMode>("name");
   const selectedSkillName = useAppStore((state) =>
     state.activeView.kind === "skill" ? state.activeView.name : null,
@@ -74,15 +73,7 @@ export function SkillsView({ snapshot, onSelectSkill }: SkillsViewProps) {
   // list is always the user's own skills.
   const baseSkills = ownSkillsView(allSkills);
   const issues = collectDashboardIssues(baseSkills);
-  const filtered = applySkillListFilter(baseSkills, filter, issues, snapshot?.invocations);
-  const trimmedQuery = query.trim().toLowerCase();
-  const rows = trimmedQuery
-    ? filtered.filter(
-        (s) =>
-          s.name.toLowerCase().includes(trimmedQuery) ||
-          (s.description ?? "").toLowerCase().includes(trimmedQuery),
-      )
-    : filtered;
+  const rows = applySkillListFilter(baseSkills, filter, issues, snapshot?.invocations);
 
   const handleAddProject = async () => {
     const selected = await open({ directory: true, multiple: false, title: "Add Project" });
@@ -146,8 +137,6 @@ export function SkillsView({ snapshot, onSelectSkill }: SkillsViewProps) {
         showCoverage={showCoverage}
         onToggleCoverage={setShowCoverage}
         resultCount={rows.length}
-        query={query}
-        onQueryChange={setQuery}
         sort={sort}
         onSortChange={setSort}
         snapshot={snapshot}
@@ -163,10 +152,7 @@ export function SkillsView({ snapshot, onSelectSkill }: SkillsViewProps) {
           selectedSkillName={selectedSkillName}
           deploymentPathForSkill={(skill) => deploymentForScope(skill, filter.scope)}
           hasAnySkills={baseSkills.length > 0}
-          onClearFilters={() => {
-            setQuery("");
-            resetSkillListFilter();
-          }}
+          onClearFilters={resetSkillListFilter}
           onAddSkill={() => openAddSkillSheet()}
         />
       )}

--- a/apps/desktop/src/lib/harness-labels.ts
+++ b/apps/desktop/src/lib/harness-labels.ts
@@ -3,7 +3,7 @@
 // / pi), consumed by SkillAssistantPanel and SkillHistorySection.
 // ============================================================================
 
-import type { AgentId } from "@skill-studio/lib";
+import type { HarnessId } from "@skill-studio/lib";
 
 /** Display label for each first-class harness, in the order the control shows them. */
 export const HARNESS_LABELS = [
@@ -11,4 +11,4 @@ export const HARNESS_LABELS = [
   ["codex", "Codex"],
   ["open-code", "OpenCode"],
   ["pi", "pi"],
-] satisfies [AgentId, string][];
+] satisfies [HarnessId, string][];

--- a/apps/desktop/src/store/appStore.test.ts
+++ b/apps/desktop/src/store/appStore.test.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
     selectedSkillPaths: new Set(),
     selectionMode: false,
     activeView: { kind: "home" },
+    skillListFilter: { scope: "all", query: "" },
   });
 });
 
@@ -97,12 +98,67 @@ describe("skillListFilter", () => {
     expect(useAppStore.getState().activeView.kind).toBe("skills");
   });
 
+  it("keeps sidebar and filter-bar query updates on the same store value", () => {
+    const updateQuery = (query: string) => useAppStore.getState().setSkillListFilter({ query });
+
+    updateQuery("from sidebar");
+    expect(useAppStore.getState().skillListFilter.query).toBe("from sidebar");
+
+    updateQuery("from filter bar");
+    expect(useAppStore.getState().skillListFilter.query).toBe("from filter bar");
+  });
+
   it("opening and closing a skill leaves the filter unchanged", () => {
     useAppStore.getState().setActiveView({ kind: "skills" });
-    useAppStore.getState().setSkillListFilter({ scope: "global" });
+    useAppStore.getState().setSkillListFilter({ scope: "global", query: "regression" });
     useAppStore.getState().openSkill("find-bugs");
     useAppStore.getState().closeSkill();
     expect(useAppStore.getState().skillListFilter.scope).toBe("global");
+    expect(useAppStore.getState().skillListFilter.query).toBe("regression");
+  });
+
+  it("changing scope clears selection mode and paths together", () => {
+    useAppStore.setState({
+      skillListFilter: { scope: "global", query: "find" },
+      selectionMode: true,
+      selectedSkillPaths: new Set(["/global/find-bugs"]),
+    });
+
+    useAppStore.getState().setSkillListFilter({ scope: { project: "/repo" } });
+
+    const state = useAppStore.getState();
+    expect(state.skillListFilter).toEqual({ scope: { project: "/repo" }, query: "find" });
+    expect(state.selectionMode).toBe(false);
+    expect(state.selectedSkillPaths).toEqual(new Set());
+  });
+
+  it("keeps selection for query and other unrelated filter changes", () => {
+    useAppStore.setState({
+      skillListFilter: { scope: "global", query: "" },
+      selectionMode: true,
+      selectedSkillPaths: new Set(["/global/find-bugs"]),
+    });
+
+    useAppStore.getState().setSkillListFilter({ query: "find", source: "manual" });
+
+    const state = useAppStore.getState();
+    expect(state.skillListFilter).toEqual({ scope: "global", query: "find", source: "manual" });
+    expect(state.selectionMode).toBe(true);
+    expect(state.selectedSkillPaths).toEqual(new Set(["/global/find-bugs"]));
+  });
+
+  it("resetting a scoped filter also clears its stale selection", () => {
+    useAppStore.setState({
+      skillListFilter: { scope: "parked", query: "" },
+      selectionMode: true,
+      selectedSkillPaths: new Set(["/parked/find-bugs"]),
+    });
+
+    useAppStore.getState().resetSkillListFilter();
+
+    expect(useAppStore.getState().skillListFilter).toEqual({ scope: "all", query: "" });
+    expect(useAppStore.getState().selectionMode).toBe(false);
+    expect(useAppStore.getState().selectedSkillPaths).toEqual(new Set());
   });
 });
 

--- a/apps/desktop/src/store/appStore.ts
+++ b/apps/desktop/src/store/appStore.ts
@@ -4,7 +4,7 @@
 // ============================================================================
 
 import { create } from "zustand";
-import { defaultSkillListFilter } from "@skill-studio/lib";
+import { defaultSkillListFilter, isProjectScope } from "@skill-studio/lib";
 import type { SkillListFilter } from "@skill-studio/lib";
 import { USAGE_WINDOWS } from "@skill-studio/lib";
 import type { UsageWindow } from "@skill-studio/lib";
@@ -134,8 +134,8 @@ interface AppState {
   // Keyed by the row's deployment directory path (`Deployment.path`), not by
   // skill name - a pack member is bundled from one specific deployment, and
   // two rows can share a name (project vs. plugin) but not a path. Cleared
-  // whenever the active view changes, so a selection made in Global doesn't
-  // linger into Project.
+  // whenever the active view or list scope changes, so a selection made in
+  // Global doesn't linger into Project.
   selectedSkillPaths: Set<string>;
   toggleSkillSelection: (path: string) => void;
   clearSkillSelection: () => void;
@@ -185,6 +185,15 @@ function savePathList(key: string, paths: string[]): void {
   }
 }
 
+/** Whether two Skills list scopes select the same global, parked, all, or project rows. */
+function sameSkillListScope(
+  left: SkillListFilter["scope"],
+  right: SkillListFilter["scope"],
+): boolean {
+  if (isProjectScope(left)) return isProjectScope(right) && left.project === right.project;
+  return left === right;
+}
+
 /** Cleans up the previous `watchSystemTheme` listener - re-set on every `setTheme` call, so only one is ever live. */
 let systemThemeCleanup: (() => void) | null = null;
 
@@ -224,8 +233,19 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   skillListFilter: defaultSkillListFilter(),
   setSkillListFilter: (patch) =>
-    set((state) => ({ skillListFilter: { ...state.skillListFilter, ...patch } })),
-  resetSkillListFilter: () => set({ skillListFilter: defaultSkillListFilter() }),
+    set((state) => {
+      const skillListFilter = { ...state.skillListFilter, ...patch };
+      return sameSkillListScope(state.skillListFilter.scope, skillListFilter.scope)
+        ? { skillListFilter }
+        : { skillListFilter, selectedSkillPaths: new Set(), selectionMode: false };
+    }),
+  resetSkillListFilter: () =>
+    set((state) => {
+      const skillListFilter = defaultSkillListFilter();
+      return sameSkillListScope(state.skillListFilter.scope, skillListFilter.scope)
+        ? { skillListFilter }
+        : { skillListFilter, selectedSkillPaths: new Set(), selectionMode: false };
+    }),
 
   showCoverage: false,
   setShowCoverage: (show) => set({ showCoverage: show }),

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "fmt:rust": "cd apps/desktop/src-tauri && cargo fmt",
-    "test": "npm run test -w skill-studio && npm run test -w @skill-studio/lib && npm run test -w @skill-studio/server",
+    "test": "npm run test -w skill-studio && npm run test -w @skill-studio/lib && npm run test -w @skill-studio/server && npm run test -w @skill-studio/marketing",
     "check": "npm run typecheck && npm run lint && npm run format:check && npm run doctor && npm run test && cd apps/desktop/src-tauri && cargo fmt --check && cargo clippy -- -D warnings && cargo test",
     "doctor": "react-doctor apps/desktop -y --no-score --no-supply-chain --blocking warning"
   },

--- a/packages/lib/src/skill-coverage.test.ts
+++ b/packages/lib/src/skill-coverage.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   AGENT_MATRIX_LABELS,
+  agentMatrix,
   agentIdFromDeploymentLabel,
   deploymentRelationText,
   driftingCopies,
@@ -12,6 +13,7 @@ import {
   locationSummary,
   pickCompareDefaults,
   resolveCompareSelection,
+  skillVisibleToAgent,
 } from "./skill-coverage";
 import type { Deployment, InstalledSkill } from "./skill-types";
 
@@ -317,6 +319,44 @@ describe("AGENT_MATRIX_LABELS", () => {
       "Cursor",
       "Grok Build",
     ]);
+  });
+});
+
+describe("disabled shared-root readers", () => {
+  it("reports a disabled reader as not visible in the coverage matrix", () => {
+    const skill = fixtureSkill({
+      deployments: [
+        fixtureDeployment({
+          agent: "shared",
+          path: "/home/.agents/skills/find-bugs",
+          disabled_readers: ["open-code"],
+        }),
+      ],
+    });
+
+    expect(skillVisibleToAgent(skill, "open-code")).toBe("none");
+    expect(skillVisibleToAgent(skill, "codex")).toBe("shared");
+    expect(agentMatrix([skill])[0]?.cells.OpenCode.state).toBe("none");
+    expect(agentMatrix([skill])[0]?.cells.Codex.state).toBe("shared");
+  });
+
+  it("prefers a healthy own deployment over a disabled shared-root reader", () => {
+    const skill = fixtureSkill({
+      deployments: [
+        fixtureDeployment({
+          agent: "shared",
+          path: "/home/.agents/skills/find-bugs",
+          disabled_readers: ["open-code"],
+        }),
+        fixtureDeployment({
+          agent: "OpenCode",
+          path: "/home/.config/opencode/skills/find-bugs",
+        }),
+      ],
+    });
+
+    expect(skillVisibleToAgent(skill, "open-code")).toBe("own");
+    expect(agentMatrix([skill])[0]?.cells.OpenCode.state).toBe("own");
   });
 });
 

--- a/packages/lib/src/skill-coverage.ts
+++ b/packages/lib/src/skill-coverage.ts
@@ -315,12 +315,17 @@ export function resolveCompareSelection(
 
 /**
  * A broken, disabled, or parked shared-root deployment doesn't make a skill
- * visible via the shared root.
+ * visible via the shared root. When `reader` is set, a shared deployment that
+ * explicitly disables that reader does not provide visibility to it.
  */
-function isSharedRootDeployment(skill: InstalledSkill): boolean {
+function isSharedRootDeployment(skill: InstalledSkill, reader?: AgentId): boolean {
   if (skill.parked) return false;
   return ownDeployments(skill).some(
-    (d) => d.agent === SHARED_AGENT_ID && !d.disabled && !isUnresolvedDeployment(d),
+    (d) =>
+      d.agent === SHARED_AGENT_ID &&
+      !d.disabled &&
+      !isUnresolvedDeployment(d) &&
+      (reader === undefined || !(d.disabled_readers ?? []).includes(reader)),
   );
 }
 
@@ -337,7 +342,9 @@ export function skillVisibleToAgent(
   agent: AgentId,
 ): "own" | "shared" | "none" {
   if (isOwnDirDeployment(skill, agent)) return "own";
-  if (AGENTS_READING_SHARED_ROOT.includes(agent) && isSharedRootDeployment(skill)) return "shared";
+  if (AGENTS_READING_SHARED_ROOT.includes(agent) && isSharedRootDeployment(skill, agent)) {
+    return "shared";
+  }
   return "none";
 }
 

--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "test": "vitest run",
     "remotion:studio": "remotion studio src/remotion/index.ts",
     "typecheck": "tsc --noEmit",
     "remotion:capture": "node scripts/capture-walkthroughs.mjs",

--- a/packages/marketing/src/ProductMock.tsx
+++ b/packages/marketing/src/ProductMock.tsx
@@ -29,6 +29,7 @@ import {
 import { AgentIcon, type AgentId } from "./AgentIcon";
 import { productDemoLightTheme, productDemoTokens as tokens } from "./ProductDemoTokens.stylex";
 import type { SiteTheme } from "./SiteTheme.stylex";
+import { productMockDetailBackLabel, type ProductMockRootView } from "./product-mock-navigation";
 
 export interface ThemeToggleOrigin {
   x: number;
@@ -38,13 +39,12 @@ export interface ThemeToggleOrigin {
 interface ProductMockProps {
   theme: SiteTheme;
   onToggleTheme: (origin: ThemeToggleOrigin) => void;
-  initialView?: RootView;
+  initialView?: ProductMockRootView;
   initialSkillName?: string;
   initialInstall?: boolean;
   variant?: "hero" | "walkthrough" | "capture";
 }
 
-type RootView = "home" | "skills" | "plugins" | "activity";
 type Scope = "All" | "Global" | "Project";
 type ActivityWindow = "24h" | "7d" | "14d" | "30d";
 type InvocationPolicy = "Both" | "User only" | "Model only";
@@ -62,7 +62,7 @@ interface SkillRow {
 
 interface DetailState {
   skill: SkillRow;
-  from: RootView;
+  from: ProductMockRootView;
 }
 
 const skills = [
@@ -210,7 +210,7 @@ const pluginGroups = [
 ];
 
 const navItems: ReadonlyArray<{
-  id: RootView;
+  id: ProductMockRootView;
   label: string;
   Icon: typeof LayoutDashboard;
   count?: number;
@@ -272,8 +272,8 @@ function Sidebar({
   theme,
   onToggleTheme,
 }: {
-  activeView: RootView;
-  onNavigate: (view: RootView) => void;
+  activeView: ProductMockRootView;
+  onNavigate: (view: ProductMockRootView) => void;
   onAddSkill: () => void;
   theme: SiteTheme;
   onToggleTheme: (origin: ThemeToggleOrigin) => void;
@@ -1093,8 +1093,7 @@ function DetailScreen({ detail, onBack }: { detail: DetailState; onBack: () => v
   const [trial, setTrial] = useState(detail.skill.trial ?? false);
   const location = detail.skill.location;
   const skillPath = `${location === "Global" ? "~/" : "agent-studio/"}.agents/skills/${detail.skill.name}`;
-  const backLabel =
-    detail.from === "home" ? "Home" : detail.from === "activity" ? "Activity" : "Skills";
+  const backLabel = productMockDetailBackLabel(detail.from);
   return (
     <section {...stylex.props(styles.page)}>
       <header {...stylex.props(styles.detailHeader)}>
@@ -1268,13 +1267,13 @@ export function ProductMock({
   variant = "hero",
 }: ProductMockProps) {
   const initialSkill = skills.find((skill) => skill.name === initialSkillName);
-  const [activeView, setActiveView] = useState<RootView>(initialView);
+  const [activeView, setActiveView] = useState<ProductMockRootView>(initialView);
   const [detail, setDetail] = useState<DetailState | null>(
     initialSkill ? { skill: initialSkill, from: initialView } : null,
   );
   const [installOpen, setInstallOpen] = useState(initialInstall);
   const [compareSkill, setCompareSkill] = useState<string | null>(null);
-  const navigate = (view: RootView) => {
+  const navigate = (view: ProductMockRootView) => {
     setActiveView(view);
     setDetail(null);
     setInstallOpen(false);

--- a/packages/marketing/src/product-mock-navigation.test.ts
+++ b/packages/marketing/src/product-mock-navigation.test.ts
@@ -1,0 +1,18 @@
+// ============================================================================
+// Skill Studio marketing demo - detail navigation label tests
+// ============================================================================
+
+import { describe, expect, it } from "vitest";
+import { productMockDetailBackLabel } from "./product-mock-navigation";
+
+describe("productMockDetailBackLabel", () => {
+  it("returns Plugins for detail opened from Plugins", () => {
+    expect(productMockDetailBackLabel("plugins")).toBe("Plugins");
+  });
+
+  it("keeps the existing labels for other root views", () => {
+    expect(productMockDetailBackLabel("home")).toBe("Home");
+    expect(productMockDetailBackLabel("skills")).toBe("Skills");
+    expect(productMockDetailBackLabel("activity")).toBe("Activity");
+  });
+});

--- a/packages/marketing/src/product-mock-navigation.ts
+++ b/packages/marketing/src/product-mock-navigation.ts
@@ -1,0 +1,19 @@
+// ============================================================================
+// Skill Studio marketing demo - detail navigation labels
+// ============================================================================
+
+export type ProductMockRootView = "home" | "skills" | "plugins" | "activity";
+
+/** Returns the root-view label shown by ProductMock's detail back button. */
+export function productMockDetailBackLabel(from: ProductMockRootView): string {
+  switch (from) {
+    case "home":
+      return "Home";
+    case "skills":
+      return "Skills";
+    case "plugins":
+      return "Plugins";
+    case "activity":
+      return "Activity";
+  }
+}


### PR DESCRIPTION
## Summary
- honor disabled shared-root readers and keep Assistant harness choices supported
- preserve Skills list scope, selection, and store-backed search state
- reset Assistant/Runs navigation and show run-start failures truthfully
- correct materialize labels, marketing back labels, and skills.sh status errors

## Verification
- 293 npm tests passed before the final focused correction
- transcript correction: 3 focused tests passed
- desktop and marketing typechecks passed
- scoped Oxlint and Oxfmt passed
- React Doctor introduced no new findings
- git diff check passed

Closes #5
Closes #14
Closes #18
Closes #19
Closes #23
Closes #29
Closes #33
Closes #34