### PR TITLE
fix: harden skill editing and proxy routes

### DIFF
--- a/apps/desktop/src-tauri/src/skills/commands.rs
+++ b/apps/desktop/src-tauri/src/skills/commands.rs
@@ -3,12 +3,11 @@
 // IPC commands for skill discovery, installation, and management
 // ============================================================================
 
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::SystemTime;
 
 use super::agents::{AgentId, AgentTarget};
 use super::api;
@@ -27,6 +26,7 @@ use super::skill_lifecycle::{
     dotagents_update_args, ledger_matching_deployment, rebuild_fresh_lifecycle_snapshot,
     resolve_lifecycle_target, skills_sh_remove_args_for_scope, skills_sh_update_args,
 };
+use super::skill_md_write::{write_skill_md, write_skill_md_compare_and_swap};
 use super::skill_refresh::{self, SkillRefreshState};
 use super::skill_trial;
 use super::skill_update_check;
@@ -437,7 +437,7 @@ mod tests {
         let snapshot = fixture_snapshot(&dep_dir, None);
         assert!(check_skill_md_write_allowed(Some(&snapshot), &skill_md).is_ok());
 
-        atomic_write_skill_md(&skill_md, "---\nname: foo\n---\nupdated body").unwrap();
+        write_skill_md(&skill_md, "---\nname: foo\n---\nupdated body").unwrap();
 
         let round_tripped = std::fs::read_to_string(&skill_md).unwrap();
         assert_eq!(round_tripped, "---\nname: foo\n---\nupdated body");
@@ -449,10 +449,10 @@ mod tests {
         let skill_md = tmp.path().join("SKILL.md");
         std::fs::write(&skill_md, "original").unwrap();
 
-        atomic_write_skill_md(&skill_md, "first save").unwrap();
+        write_skill_md(&skill_md, "first save").unwrap();
         assert_eq!(std::fs::read_to_string(&skill_md).unwrap(), "first save");
 
-        atomic_write_skill_md(&skill_md, "second save").unwrap();
+        write_skill_md(&skill_md, "second save").unwrap();
         assert_eq!(std::fs::read_to_string(&skill_md).unwrap(), "second save");
     }
 
@@ -464,7 +464,7 @@ mod tests {
         let canonical = tmp.path().join("SKILL.md");
         std::fs::create_dir_all(&canonical).unwrap();
 
-        let err = atomic_write_skill_md(&canonical, "content");
+        let err = write_skill_md(&canonical, "content");
         assert!(err.is_err());
 
         let leftover_temp_files = std::fs::read_dir(tmp.path())
@@ -499,6 +499,48 @@ mod tests {
 
         write_skill_md_compare_and_swap(&skill_md, "on disk now", "new content").unwrap();
         assert_eq!(std::fs::read_to_string(&skill_md).unwrap(), "new content");
+    }
+
+    #[test]
+    fn concurrent_compare_and_swap_allows_only_one_matching_write() {
+        use std::sync::{mpsc, Arc};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_md = Arc::new(tmp.path().join("SKILL.md"));
+        std::fs::write(skill_md.as_ref(), "shared baseline").unwrap();
+
+        let first_path = Arc::clone(&skill_md);
+        let (first_compared_tx, first_compared_rx) = mpsc::channel();
+        let (release_first_tx, release_first_rx) = mpsc::channel();
+        let first = std::thread::spawn(move || {
+            super::super::skill_md_write::write_skill_md_compare_and_swap_with(
+                &first_path,
+                "shared baseline",
+                "first write",
+                || {
+                    let _ = first_compared_tx.send(());
+                    let _ = release_first_rx.recv();
+                },
+            )
+        });
+
+        first_compared_rx.recv().unwrap();
+        let lock_was_held_across_compare =
+            super::super::skill_md_write::skill_md_write_transaction_is_held();
+        let second_path = Arc::clone(&skill_md);
+        let second = std::thread::spawn(move || {
+            write_skill_md_compare_and_swap(&second_path, "shared baseline", "second write")
+        });
+        release_first_tx.send(()).unwrap();
+
+        let results = [first.join().unwrap(), second.join().unwrap()];
+        assert!(lock_was_held_across_compare);
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+        assert_eq!(
+            std::fs::read_to_string(skill_md.as_ref()).unwrap(),
+            "first write"
+        );
     }
 
     fn dotagents_skill(
@@ -2235,61 +2277,6 @@ pub(crate) fn check_skill_md_write_allowed(
     }
 }
 
-/// Counter appended to the atomic-write temp filename, on top of the pid and
-/// a timestamp, so two saves landing in the same process within the same
-/// nanosecond still get distinct temp files.
-static ATOMIC_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Writes `content` to `canonical` atomically: a temp file in the same
-/// directory, then a rename, so a crash mid-write can't leave a truncated
-/// `SKILL.md` behind. Pulled out of the command so it's testable with a
-/// plain tempdir, no snapshot or `tauri::AppHandle` needed.
-///
-/// The temp filename is unique per call (pid + a process-wide counter +
-/// wall-clock nanos) and created with `create_new` so a concurrent save, or a
-/// pre-existing symlink at that path, can't be interleaved or truncated.
-pub(crate) fn atomic_write_skill_md(
-    canonical: &std::path::Path,
-    content: &str,
-) -> Result<(), String> {
-    let parent = canonical.parent().ok_or_else(|| {
-        format!(
-            "Failed to resolve parent directory of {}",
-            canonical.display()
-        )
-    })?;
-    let counter = ATOMIC_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let nanos = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let tmp_path = parent.join(format!(
-        ".SKILL.md.tmp-{}-{}-{}",
-        std::process::id(),
-        counter,
-        nanos
-    ));
-
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&tmp_path)
-        .map_err(|e| format!("Failed to create {}: {}", tmp_path.display(), e))?;
-    let write_result = file
-        .write_all(content.as_bytes())
-        .and_then(|_| file.sync_all());
-    drop(file);
-    if let Err(e) = write_result {
-        let _ = std::fs::remove_file(&tmp_path);
-        return Err(format!("Failed to write {}: {}", tmp_path.display(), e));
-    }
-
-    std::fs::rename(&tmp_path, canonical).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp_path);
-        format!("Failed to save {}: {}", canonical.display(), e)
-    })
-}
-
 /// Runs every check `write_installed_skill_md` and
 /// `write_installed_skill_md_if_unchanged` share - ownership, canonicalization,
 /// the size limit, and the plugin-managed refusal - and returns the canonical
@@ -2328,36 +2315,16 @@ pub fn write_installed_skill_md(
     refresh_state: tauri::State<SkillRefreshState>,
 ) -> Result<(), String> {
     let canonical = validate_skill_md_write(&path, &content, &refresh_state)?;
-    atomic_write_skill_md(&canonical, &content)?;
+    write_skill_md(&canonical, &content)?;
     skill_refresh::request_snapshot_rebuild(&app);
     Ok(())
 }
 
-/// Refuses when `canonical`'s current content differs from `expected_content`
-/// (the file drifted on disk since the caller loaded it), otherwise writes
-/// atomically. Pulled out of the command so it's testable without a snapshot
-/// or `tauri::AppHandle`.
-pub(crate) fn write_skill_md_compare_and_swap(
-    canonical: &std::path::Path,
-    expected_content: &str,
-    content: &str,
-) -> Result<(), String> {
-    let current = std::fs::read_to_string(canonical)
-        .map_err(|e| format!("Failed to open {}: {}", canonical.display(), e))?;
-    if current != expected_content {
-        return Err(
-            "SKILL.md changed on disk since it was loaded. Reload the file and run the audit again."
-                .to_string(),
-        );
-    }
-    atomic_write_skill_md(canonical, content)
-}
-
 /// Like `write_installed_skill_md`, but refuses the write (rather than
 /// silently overwriting) when the file's current content doesn't match
-/// `expected_content` - the copy the caller last loaded. Used by the Audit
-/// proposal's Apply action so a save made elsewhere while the proposal was
-/// open can't be clobbered.
+/// `expected_content` - the copy the caller last loaded. Used by Audit
+/// proposal Apply and the inline editor to detect an ordinary stale baseline
+/// before writing.
 #[tauri::command]
 pub fn write_installed_skill_md_if_unchanged(
     path: String,

--- a/apps/desktop/src-tauri/src/skills/event_store.rs
+++ b/apps/desktop/src-tauri/src/skills/event_store.rs
@@ -33,6 +33,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use super::skill_md_write::{begin_skill_md_write_transaction, SkillMdWriteTransaction};
+
 /// Opens (creating if absent) the event store DB at `db_path` and ensures
 /// its schema exists.
 pub fn open(db_path: &Path) -> Result<Connection, String> {
@@ -379,6 +381,15 @@ impl EventStore {
     /// created to do it. See the module header for the drift-guard and
     /// restore-of-restore design.
     pub fn restore(&self, target_id: &str, force: bool) -> Result<String, String> {
+        self.restore_with_skill_md_transaction_observer(target_id, force, |_| {})
+    }
+
+    fn restore_with_skill_md_transaction_observer(
+        &self,
+        target_id: &str,
+        force: bool,
+        observe_transaction: impl FnOnce(Option<&SkillMdWriteTransaction>),
+    ) -> Result<String, String> {
         let target = self
             .get_event(target_id)?
             .ok_or_else(|| format!("Event {target_id} not found"))?;
@@ -395,6 +406,15 @@ impl EventStore {
         let inverse: InverseOp = serde_json::from_value(inverse_value)
             .map_err(|e| format!("Failed to parse inverse for {target_id}: {e}"))?;
 
+        let skill_md_transaction = (inverse
+            .destination()
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some("SKILL.md"))
+        .then(begin_skill_md_write_transaction)
+        .transpose()?;
+        observe_transaction(skill_md_transaction.as_ref());
+
         let restore_id = allocate_id();
         let claimed = self
             .conn
@@ -407,7 +427,7 @@ impl EventStore {
             return Err(format!("Event {target_id} was already restored"));
         }
 
-        match self.apply_restore(&restore_id, &target, &inverse, force) {
+        let result = match self.apply_restore(&restore_id, &target, &inverse, force) {
             Ok(()) => Ok(restore_id),
             Err(e) => {
                 let _ = self.conn.execute(
@@ -416,7 +436,9 @@ impl EventStore {
                 );
                 Err(e)
             }
-        }
+        };
+        drop(skill_md_transaction);
+        result
     }
 
     fn apply_restore(
@@ -1194,6 +1216,7 @@ pub struct MaterializedRoot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::skills::skill_md_write::skill_md_write_transaction_is_held;
     use std::os::unix::fs::symlink;
 
     fn store(dir: &Path) -> EventStore {
@@ -1416,6 +1439,104 @@ mod tests {
         // right before the first restore ran.
         store.restore(&restore_id, false).unwrap();
         assert_eq!(fingerprint_path(&path), "absent");
+    }
+
+    #[test]
+    fn repair_undo_and_redo_hold_skill_md_transaction_but_other_files_do_not() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = store(tmp.path());
+        let skill_md = tmp.path().join("skills/sample/SKILL.md");
+        fs::create_dir_all(skill_md.parent().unwrap()).unwrap();
+        fs::write(&skill_md, b"malformed frontmatter").unwrap();
+        let malformed_fingerprint = fingerprint_path(&skill_md);
+
+        let repair_id = allocate_id();
+        store
+            .backup_paths(&repair_id, std::slice::from_ref(&skill_md))
+            .unwrap();
+        fs::write(&skill_md, b"repaired frontmatter").unwrap();
+        let repair_inverse = InverseOp::RestoreBackup {
+            path: skill_md.clone(),
+            pre_fingerprint: malformed_fingerprint,
+            post_fingerprint: Some(fingerprint_path(&skill_md)),
+        };
+        store
+            .record(
+                &repair_id,
+                draft(
+                    "repair_skill_frontmatter",
+                    "sample",
+                    serde_json::json!({}),
+                    Some(serde_json::to_value(repair_inverse).unwrap()),
+                    Some(format!("backups/{repair_id}")),
+                ),
+            )
+            .unwrap();
+        store.finish(&repair_id, EventStatus::Done).unwrap();
+
+        let undo_id = store
+            .restore_with_skill_md_transaction_observer(&repair_id, false, |transaction| {
+                assert!(transaction.is_some());
+                assert!(skill_md_write_transaction_is_held());
+            })
+            .unwrap();
+        assert_eq!(fs::read(&skill_md).unwrap(), b"malformed frontmatter");
+        assert_eq!(
+            store
+                .get(&repair_id)
+                .unwrap()
+                .unwrap()
+                .reverted_by
+                .as_deref(),
+            Some(undo_id.as_str())
+        );
+
+        let redo_id = store
+            .restore_with_skill_md_transaction_observer(&undo_id, false, |transaction| {
+                assert!(transaction.is_some());
+                assert!(skill_md_write_transaction_is_held());
+            })
+            .unwrap();
+        assert_eq!(fs::read(&skill_md).unwrap(), b"repaired frontmatter");
+        assert_eq!(
+            store.get(&undo_id).unwrap().unwrap().reverted_by.as_deref(),
+            Some(redo_id.as_str())
+        );
+        assert_eq!(store.get(&redo_id).unwrap().unwrap().status, "done");
+
+        let ordinary_file = tmp.path().join("notes.md");
+        fs::write(&ordinary_file, b"before").unwrap();
+        let ordinary_before_fingerprint = fingerprint_path(&ordinary_file);
+        let ordinary_id = allocate_id();
+        store
+            .backup_paths(&ordinary_id, std::slice::from_ref(&ordinary_file))
+            .unwrap();
+        fs::write(&ordinary_file, b"after").unwrap();
+        let ordinary_inverse = InverseOp::RestoreBackup {
+            path: ordinary_file.clone(),
+            pre_fingerprint: ordinary_before_fingerprint,
+            post_fingerprint: Some(fingerprint_path(&ordinary_file)),
+        };
+        store
+            .record(
+                &ordinary_id,
+                draft(
+                    "update_notes",
+                    "sample",
+                    serde_json::json!({}),
+                    Some(serde_json::to_value(ordinary_inverse).unwrap()),
+                    Some(format!("backups/{ordinary_id}")),
+                ),
+            )
+            .unwrap();
+        store.finish(&ordinary_id, EventStatus::Done).unwrap();
+
+        store
+            .restore_with_skill_md_transaction_observer(&ordinary_id, false, |transaction| {
+                assert!(transaction.is_none());
+            })
+            .unwrap();
+        assert_eq!(fs::read(ordinary_file).unwrap(), b"before");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/skills/mod.rs
+++ b/apps/desktop/src-tauri/src/skills/mod.rs
@@ -39,6 +39,7 @@ pub mod skill_invocation;
 pub mod skill_invocations;
 pub mod skill_lifecycle;
 pub mod skill_materialize;
+pub mod skill_md_write;
 pub mod skill_ownership;
 pub mod skill_pack;
 pub mod skill_park;

--- a/apps/desktop/src-tauri/src/skills/skill_frontmatter_repair.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_frontmatter_repair.rs
@@ -5,7 +5,6 @@
 // ============================================================================
 
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -20,6 +19,7 @@ use super::frontmatter::{parse_frontmatter, FrontmatterParseResult};
 use super::skill_deployment::{BackingRelationship, DeploymentMutability, SkillDestination};
 use super::skill_dto::{Deployment, LifecycleTarget};
 use super::skill_fork::ForkMutationLock;
+use super::skill_md_write::{begin_skill_md_write_transaction, SkillMdWriteTransaction};
 use super::skill_ownership::LifecycleOwnerKind;
 use super::skill_refresh::{self, SkillRefreshState};
 
@@ -246,6 +246,20 @@ fn validate_bound_preview(
     Ok(preview)
 }
 
+fn begin_bound_frontmatter_repair_transaction(
+    deployment: &Deployment,
+    expected_content_fingerprint: &str,
+    expected_proposal_id: &str,
+) -> Result<(SkillMdWriteTransaction, FrontmatterRepairPreview), String> {
+    let transaction = begin_skill_md_write_transaction()?;
+    let preview = validate_bound_preview(
+        deployment,
+        expected_content_fingerprint,
+        expected_proposal_id,
+    )?;
+    Ok((transaction, preview))
+}
+
 fn exact_target<'a>(
     snapshot: &'a skill_refresh::SkillSnapshot,
     target: &LifecycleTarget,
@@ -270,35 +284,6 @@ pub fn preview_skill_frontmatter_repair(
 ) -> Result<FrontmatterRepairPreview, String> {
     let snapshot = super::skill_lifecycle::rebuild_fresh_lifecycle_snapshot(&app, &refresh_state)?;
     preview_from_deployment(exact_target(&snapshot, &target)?)
-}
-
-fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
-    let parent = path.parent().ok_or("SKILL.md has no parent directory")?;
-    let permissions = fs::metadata(path)
-        .map_err(|error| format!("Failed to stat {}: {error}", path.display()))?
-        .permissions();
-    let temp = parent.join(format!(".SKILL.md.repair-{}", allocate_id()));
-    let result = (|| {
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp)
-            .map_err(|error| format!("Failed to create repair file: {error}"))?;
-        file.write_all(bytes)
-            .map_err(|error| format!("Failed to write repair file: {error}"))?;
-        file.sync_all()
-            .map_err(|error| format!("Failed to sync repair file: {error}"))?;
-        fs::set_permissions(&temp, permissions)
-            .map_err(|error| format!("Failed to preserve SKILL.md permissions: {error}"))?;
-        fs::rename(&temp, path).map_err(|error| format!("Failed to replace SKILL.md: {error}"))?;
-        fs::File::open(parent)
-            .and_then(|dir| dir.sync_all())
-            .map_err(|error| format!("Failed to sync skill directory: {error}"))
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(temp);
-    }
-    result
 }
 
 fn finish_repair_write(
@@ -372,11 +357,21 @@ pub fn reconcile_interrupted_frontmatter_repair(
     home: &Path,
     row: &EventRow,
 ) -> Result<(), String> {
+    reconcile_interrupted_frontmatter_repair_with(store, home, row, |_| {})
+}
+
+fn reconcile_interrupted_frontmatter_repair_with(
+    store: &EventStore,
+    home: &Path,
+    row: &EventRow,
+    after_read: impl FnOnce(&SkillMdWriteTransaction),
+) -> Result<(), String> {
+    let transaction = begin_skill_md_write_transaction()?;
     let intent: FrontmatterRepairIntent = serde_json::from_value(row.payload.clone())
         .map_err(|error| format!("Malformed frontmatter repair intent: {error}"))?;
     let skill_md = intent.path.join("SKILL.md");
-    let current = fs::read(&skill_md)
-        .map_err(|error| format!("Failed to read {}: {error}", skill_md.display()))?;
+    let current = transaction.read(&skill_md)?;
+    after_read(&transaction);
     let current_fingerprint = content_fingerprint(&current);
     if current_fingerprint == intent.proposed_content_fingerprint {
         store.patch_inverse_post_fingerprint(&row.id, &fingerprint_path(&skill_md))?;
@@ -403,7 +398,7 @@ pub fn reconcile_interrupted_frontmatter_repair(
         &row.id,
         &skill_md,
         intent.proposed_content.as_bytes(),
-        atomic_write,
+        |path, bytes| transaction.replace_bytes(path, bytes),
     )
 }
 
@@ -424,11 +419,6 @@ pub fn apply_skill_frontmatter_repair(
     let _guard = fork_lock.try_acquire()?;
     let snapshot = super::skill_lifecycle::rebuild_fresh_lifecycle_snapshot(&app, &refresh_state)?;
     let deployment = exact_target(&snapshot, &target)?.clone();
-    let preview = validate_bound_preview(&deployment, &expected_content_fingerprint, &proposal_id)?;
-    if !preview.allowed_apply_modes.contains(&mode) {
-        return Err("This repair mode is not allowed for the selected deployment".to_string());
-    }
-
     let skill_md = PathBuf::from(&deployment.path).join("SKILL.md");
     let name = super::skill_deployment::parse_deployment_id(&deployment.id)
         .map(|id| id.name)
@@ -438,6 +428,14 @@ pub fn apply_skill_frontmatter_repair(
         .lock()
         .map_err(|error| format!("event store lock poisoned: {error}"))?;
     let store = guard.as_mut().ok_or("Event store is unavailable")?;
+    let (transaction, preview) = begin_bound_frontmatter_repair_transaction(
+        &deployment,
+        &expected_content_fingerprint,
+        &proposal_id,
+    )?;
+    if !preview.allowed_apply_modes.contains(&mode) {
+        return Err("This repair mode is not allowed for the selected deployment".to_string());
+    }
     let event_id = allocate_id();
     let pre_fingerprint = fingerprint_path(&skill_md);
     let intent = FrontmatterRepairIntent {
@@ -496,7 +494,8 @@ pub fn apply_skill_frontmatter_repair(
             store.finish(&event_id, EventStatus::Failed)?;
             return Err(error);
         }
-        let live = fs::read(Path::new(&deployment.path).join("SKILL.md"))
+        let live = transaction
+            .read(&skill_md)
             .map_err(|error| format!("Fork completed, but the repair needs recovery: {error}"))?;
         if content_fingerprint(&live) != expected_content_fingerprint {
             return Err(
@@ -508,19 +507,22 @@ pub fn apply_skill_frontmatter_repair(
     let result = if mode == FrontmatterRepairApplyMode::ForkAndFix {
         // Keep durable intent pending if the write fails. Startup can safely
         // finish it because the exact fork record and source fingerprint bind it.
-        atomic_write(&skill_md, preview.proposed_content.as_bytes()).and_then(|()| {
-            store.patch_inverse_post_fingerprint(&event_id, &fingerprint_path(&skill_md))?;
-            store.finish(&event_id, EventStatus::Done)
-        })
+        transaction
+            .replace_bytes(&skill_md, preview.proposed_content.as_bytes())
+            .and_then(|()| {
+                store.patch_inverse_post_fingerprint(&event_id, &fingerprint_path(&skill_md))?;
+                store.finish(&event_id, EventStatus::Done)
+            })
     } else {
         finish_repair_write(
             store,
             &event_id,
             &skill_md,
             preview.proposed_content.as_bytes(),
-            atomic_write,
+            |path, bytes| transaction.replace_bytes(path, bytes),
         )
     };
+    drop(transaction);
     drop(guard);
     let affected_projects: Vec<PathBuf> = deployment
         .project_path
@@ -543,6 +545,7 @@ mod tests {
     use super::super::skill_fork_registry::{
         write_fork_registry, ForkRecord, ForkRegistry, OriginTool,
     };
+    use super::super::skill_md_write::{skill_md_write_transaction_is_held, write_skill_md_bytes};
     use super::*;
 
     fn malformed() -> &'static str {
@@ -744,6 +747,33 @@ mod tests {
     }
 
     #[test]
+    fn repair_apply_validation_and_replace_hold_the_skill_md_transaction() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill = temp.path().join("sample");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), malformed()).unwrap();
+        let deployment = deployment(&skill, LifecycleOwnerKind::Manual);
+        let preview = preview_from_deployment(&deployment).unwrap();
+
+        let (transaction, validated) = begin_bound_frontmatter_repair_transaction(
+            &deployment,
+            &preview.expected_content_fingerprint,
+            &preview.proposal_id,
+        )
+        .unwrap();
+        assert!(skill_md_write_transaction_is_held());
+        transaction
+            .replace_text(&skill.join("SKILL.md"), &validated.proposed_content)
+            .unwrap();
+        drop(transaction);
+
+        assert_eq!(
+            fs::read_to_string(skill.join("SKILL.md")).unwrap(),
+            preview.proposed_content
+        );
+    }
+
+    #[test]
     fn direct_write_changes_only_the_exact_scope_and_keeps_managed_registry_ownership() {
         let temp = tempfile::tempdir().unwrap();
         let selected = temp.path().join("global/sample");
@@ -755,7 +785,7 @@ mod tests {
         let deployment = deployment(&selected, LifecycleOwnerKind::SkillsSh);
         let owner_before = deployment.owner_id.clone();
         let preview = preview_from_deployment(&deployment).unwrap();
-        atomic_write(
+        write_skill_md_bytes(
             &selected.join("SKILL.md"),
             preview.proposed_content.as_bytes(),
         )
@@ -807,7 +837,7 @@ mod tests {
             "repair-2",
             &skill.join("SKILL.md"),
             intent.proposed_content.as_bytes(),
-            atomic_write,
+            write_skill_md_bytes,
         )
         .unwrap();
         fs::write(skill.join("SKILL.md"), "external drift").unwrap();
@@ -855,7 +885,10 @@ mod tests {
         );
         write_fork_registry(&home, &registry).unwrap();
         let rows = store.reconcile_at_startup().unwrap();
-        reconcile_interrupted_frontmatter_repair(&store, &home, &rows[0]).unwrap();
+        reconcile_interrupted_frontmatter_repair_with(&store, &home, &rows[0], |_| {
+            assert!(skill_md_write_transaction_is_held());
+        })
+        .unwrap();
         assert_eq!(
             fs::read_to_string(skill.join("SKILL.md")).unwrap(),
             intent.proposed_content

--- a/apps/desktop/src-tauri/src/skills/skill_invocation.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_invocation.rs
@@ -19,10 +19,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::commands::{
-    atomic_write_skill_md, canonicalize_skill_md, check_skill_md_write_allowed,
-    require_snapshot_owns_path,
+    canonicalize_skill_md, check_skill_md_write_allowed, require_snapshot_owns_path,
 };
 use super::frontmatter::{invocation_policy, parse_frontmatter, InvocationPolicy};
+use super::skill_md_write::begin_skill_md_write_transaction;
 use super::skill_refresh::{self, SkillRefreshState};
 
 /// Strips a line's trailing terminator (`\r\n` or `\n`), if it has one - used
@@ -252,10 +252,21 @@ pub fn set_skill_invocation_with(
     policy: InvocationPolicy,
     has_codex_deployment: bool,
 ) -> Result<(), String> {
-    let current = fs::read_to_string(canonical_skill_md)
-        .map_err(|e| format!("Failed to open {}: {e}", canonical_skill_md.display()))?;
+    set_skill_invocation_with_read_hook(canonical_skill_md, policy, has_codex_deployment, || {})
+}
+
+fn set_skill_invocation_with_read_hook(
+    canonical_skill_md: &Path,
+    policy: InvocationPolicy,
+    has_codex_deployment: bool,
+    after_read: impl FnOnce(),
+) -> Result<(), String> {
+    let transaction = begin_skill_md_write_transaction()?;
+    let current = transaction.read_to_string(canonical_skill_md)?;
+    after_read();
     let updated = rewrite_invocation_frontmatter(&current, policy)?;
-    atomic_write_skill_md(canonical_skill_md, &updated)?;
+    transaction.replace_text(canonical_skill_md, &updated)?;
+    drop(transaction);
 
     if has_codex_deployment {
         let skill_dir = canonical_skill_md
@@ -361,6 +372,29 @@ mod tests {
         set_skill_invocation_with(&skill_md, InvocationPolicy::UserOnly, false).unwrap();
         let content = fs::read_to_string(&skill_md).unwrap();
         assert!(content.contains("disable-model-invocation: true"));
+    }
+
+    #[test]
+    fn invocation_read_and_replace_share_the_skill_md_write_transaction() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_md = tmp.path().join("SKILL.md");
+        fs::write(
+            &skill_md,
+            "---\nname: find-bugs\ndescription: test\n---\nBody.",
+        )
+        .unwrap();
+
+        set_skill_invocation_with_read_hook(&skill_md, InvocationPolicy::UserOnly, false, || {
+            assert!(
+                super::super::skill_md_write::skill_md_write_transaction_is_held(),
+                "invocation read completed without the SKILL.md transaction"
+            );
+        })
+        .unwrap();
+
+        assert!(fs::read_to_string(skill_md)
+            .unwrap()
+            .contains("disable-model-invocation: true"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/skills/skill_md_write.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_md_write.rs
@@ -1,0 +1,171 @@
+// ============================================================================
+// Skills Module - coordinated SKILL.md writes
+// Serializes editor-style SKILL.md read-modify-write operations in this
+// process and provides their atomic file-replacement primitive.
+// ============================================================================
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::SystemTime;
+
+/// Counter appended to the atomic-write temp filename, on top of the pid and
+/// a timestamp, so two saves in the same nanosecond still get distinct files.
+static ATOMIC_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+static SKILL_MD_WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Capability for reading and replacing SKILL.md while the process-wide
+/// write transaction is held. External editors do not participate in it.
+pub(crate) struct SkillMdWriteTransaction {
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl SkillMdWriteTransaction {
+    /// Reads text that will be checked or rewritten before this transaction
+    /// replaces the same SKILL.md.
+    pub(crate) fn read_to_string(&self, path: &Path) -> Result<String, String> {
+        fs::read_to_string(path).map_err(|error| {
+            format!(
+                "Failed to open {} during SKILL.md write transaction: {error}",
+                path.display()
+            )
+        })
+    }
+
+    /// Reads bytes that will be checked before this transaction replaces the
+    /// same SKILL.md.
+    pub(crate) fn read(&self, path: &Path) -> Result<Vec<u8>, String> {
+        fs::read(path).map_err(|error| {
+            format!(
+                "Failed to read {} during SKILL.md write transaction: {error}",
+                path.display()
+            )
+        })
+    }
+
+    /// Atomically replaces SKILL.md bytes without reacquiring the transaction
+    /// lock. Callers can safely use it after a read or drift check on `self`.
+    pub(crate) fn replace_bytes(&self, path: &Path, bytes: &[u8]) -> Result<(), String> {
+        atomic_replace_skill_md_unlocked(path, bytes)
+    }
+
+    /// Atomically replaces SKILL.md text without reacquiring the transaction
+    /// lock. Callers can safely use it after a read or drift check on `self`.
+    pub(crate) fn replace_text(&self, path: &Path, content: &str) -> Result<(), String> {
+        self.replace_bytes(path, content.as_bytes())
+    }
+}
+
+/// Starts one app-managed SKILL.md write transaction. Keep the returned
+/// capability alive across every read or drift check and its replacement.
+pub(crate) fn begin_skill_md_write_transaction() -> Result<SkillMdWriteTransaction, String> {
+    let guard = SKILL_MD_WRITE_LOCK.lock().map_err(|_| {
+        "SKILL.md write transaction lock is poisoned. Restart Skill Studio before editing SKILL.md again."
+            .to_string()
+    })?;
+    Ok(SkillMdWriteTransaction { _guard: guard })
+}
+
+/// Atomically replaces SKILL.md in one app-managed write transaction.
+pub(crate) fn write_skill_md(path: &Path, content: &str) -> Result<(), String> {
+    begin_skill_md_write_transaction()?.replace_text(path, content)
+}
+
+/// Atomically replaces SKILL.md bytes in one app-managed write transaction.
+#[cfg(test)]
+pub(crate) fn write_skill_md_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    begin_skill_md_write_transaction()?.replace_bytes(path, bytes)
+}
+
+/// Compares and atomically replaces SKILL.md in one app-managed transaction.
+pub(crate) fn write_skill_md_compare_and_swap(
+    path: &Path,
+    expected_content: &str,
+    content: &str,
+) -> Result<(), String> {
+    let transaction = begin_skill_md_write_transaction()?;
+    compare_and_replace_skill_md(&transaction, path, expected_content, content, || {})
+}
+
+fn compare_and_replace_skill_md(
+    transaction: &SkillMdWriteTransaction,
+    path: &Path,
+    expected_content: &str,
+    content: &str,
+    before_replace: impl FnOnce(),
+) -> Result<(), String> {
+    let current = transaction.read_to_string(path)?;
+    if current != expected_content {
+        return Err(
+            "SKILL.md changed on disk since it was loaded. Reload the file and run the audit again."
+                .to_string(),
+        );
+    }
+    before_replace();
+    transaction.replace_text(path, content)
+}
+
+#[cfg(test)]
+pub(crate) fn write_skill_md_compare_and_swap_with(
+    path: &Path,
+    expected_content: &str,
+    content: &str,
+    before_replace: impl FnOnce(),
+) -> Result<(), String> {
+    let transaction = begin_skill_md_write_transaction()?;
+    compare_and_replace_skill_md(
+        &transaction,
+        path,
+        expected_content,
+        content,
+        before_replace,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn skill_md_write_transaction_is_held() -> bool {
+    SKILL_MD_WRITE_LOCK.try_lock().is_err()
+}
+
+fn atomic_replace_skill_md_unlocked(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Failed to resolve parent directory of {}", path.display()))?;
+    let permissions = fs::metadata(path)
+        .map_err(|error| format!("Failed to stat {}: {error}", path.display()))?
+        .permissions();
+    let counter = ATOMIC_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let temp = parent.join(format!(
+        ".SKILL.md.tmp-{}-{counter}-{nanos}",
+        std::process::id()
+    ));
+
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)
+            .map_err(|error| format!("Failed to create {}: {error}", temp.display()))?;
+        file.write_all(bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| format!("Failed to write {}: {error}", temp.display()))?;
+        fs::set_permissions(&temp, permissions)
+            .map_err(|error| format!("Failed to preserve SKILL.md permissions: {error}"))?;
+        fs::rename(&temp, path)
+            .map_err(|error| format!("Failed to save {}: {error}", path.display()))?;
+        fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| format!("Failed to sync skill directory: {error}"))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temp);
+    }
+    result
+}

--- a/apps/desktop/src/components/SkillDetail/SkillMarkdownCard.tsx
+++ b/apps/desktop/src/components/SkillDetail/SkillMarkdownCard.tsx
@@ -20,7 +20,7 @@ import { SkillMarkdownEditor } from "./SkillMarkdownEditor";
  */
 export type SkillMarkdownEditState =
   | { kind: "viewing" }
-  | { kind: "editing"; isDirty: boolean; isSaving: boolean };
+  | { kind: "editing"; openedContent: string; isDirty: boolean; isSaving: boolean };
 
 interface SkillMarkdownCardProps {
   skill: InstalledSkill;
@@ -144,7 +144,7 @@ export function SkillMarkdownCard({
         </p>
       ) : editState.kind === "editing" && rawContent !== null ? (
         <SkillMarkdownEditor
-          initialContent={rawContent}
+          initialContent={editState.openedContent}
           isSaving={editState.isSaving}
           saveLabel={saveLabel}
           onSave={onSave}

--- a/apps/desktop/src/components/SkillDetail/SkillPage.tsx
+++ b/apps/desktop/src/components/SkillDetail/SkillPage.tsx
@@ -11,7 +11,7 @@ import {
   forkSkill,
   previewSkillFrontmatterRepair,
   readInstalledSkillMd,
-  writeInstalledSkillMd,
+  writeInstalledSkillMdIfUnchanged,
 } from "../../lib/skill-api";
 import { lifecycleTargetForDeployment } from "../../lib/skill-lifecycle-target";
 import { isFeatureEnabled } from "../../lib/feature-flags";
@@ -34,6 +34,7 @@ import { SkillFrontmatterRepairDialog } from "./SkillFrontmatterRepairDialog";
 import { SkillLocationsCard } from "./SkillLocationsCard";
 import { SkillMarkdownCard } from "./SkillMarkdownCard";
 import { SkillRepairCard } from "./SkillRepairCard";
+import { saveSkillEditorDraft } from "./skill-editor-save";
 import { hasMalformedYamlWarning } from "./skill-frontmatter-repair-policy";
 
 interface SkillPageProps {
@@ -110,7 +111,7 @@ function useSkillMdContent({ skill, skillMdPath, deployment, addToast }: UseSkil
 
   // A Promise chain, not a try/finally statement, so the compiler can still
   // optimize this component (it doesn't support `finally` clauses yet).
-  const handleSave = (content: string, onSaved: () => void) => {
+  const handleSave = (content: string, openedContent: string, onSaved: () => void) => {
     // Ignore a duplicate save request (e.g. Cmd+S fired while the Save
     // button's own click is already in flight).
     if (!skill || !skillMdPath || isSaving) return;
@@ -136,16 +137,24 @@ function useSkillMdContent({ skill, skillMdPath, deployment, addToast }: UseSkil
     return forkIfNeeded
       .then(() => {
         if (forkFailed) return;
-        return writeInstalledSkillMd(skillMdPath, content).then(() => {
-          setRawContent(content);
+        return saveSkillEditorDraft(
+          { path: skillMdPath, openedContent, draftContent: content },
+          writeInstalledSkillMdIfUnchanged,
+        ).then((savedDraft) => {
+          setRawContent(savedDraft.openedContent);
           onSaved();
         });
       })
       .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        const isConflict = message.includes("SKILL.md changed on disk since it was loaded");
+        if (isConflict) loadContent(skillMdPath, false);
         addToast({
           type: "error",
-          title: "Couldn't save SKILL.md",
-          message: err instanceof Error ? err.message : "Unknown error",
+          title: isConflict ? "SKILL.md changed on disk" : "Couldn't save SKILL.md",
+          message: isConflict
+            ? "Your draft is still open. Cancel editing to view the latest file; you will be asked before the draft is discarded."
+            : message,
         });
       })
       .finally(() => {
@@ -199,7 +208,8 @@ export function SkillPage({
   const setIsAssistantOpen = useAppStore((state) => state.setIsAssistantOpen);
   const { isRunsOpen, openAssistant, closeAssistant, openRuns, closeRuns } =
     useSkillAssistantNavigation(skill?.name, setIsAssistantOpen);
-  const [isEditing, setIsEditing] = useState(false);
+  const [editorOpenedContent, setEditorOpenedContent] = useState<string | null>(null);
+  const isEditing = editorOpenedContent !== null;
   const [isEditorDirty, setIsEditorDirty] = useState(false);
   const [isCompareOpen, setIsCompareOpen] = useState(false);
   const [frontmatterRepair, setFrontmatterRepair] = useState<FrontmatterRepairPreview | null>(null);
@@ -326,7 +336,7 @@ export function SkillPage({
   if (editSkillNameRef.current !== skill?.name) {
     // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- adjust-during-render, per React docs "storing information from previous renders"
     editSkillNameRef.current = skill?.name;
-    if (isEditing) setIsEditing(false);
+    if (isEditing) setEditorOpenedContent(null);
     if (isEditorDirty) setIsEditorDirty(false);
   }
 
@@ -337,15 +347,22 @@ export function SkillPage({
   if (editSkillMdPathRef.current !== skillMdPath) {
     // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- adjust-during-render, per React docs "storing information from previous renders"
     editSkillMdPathRef.current = skillMdPath;
-    if (isEditing) setIsEditing(false);
+    if (isEditing) setEditorOpenedContent(null);
     if (isEditorDirty) setIsEditorDirty(false);
   }
 
   const handleSave = (content: string) => {
-    saveContent(content, () => {
-      setIsEditing(false);
+    if (editorOpenedContent === null) return;
+    saveContent(content, editorOpenedContent, () => {
+      setEditorOpenedContent(null);
       setIsEditorDirty(false);
     });
+  };
+
+  const startEditing = () => {
+    if (rawContent === null) return;
+    setEditorOpenedContent(rawContent);
+    setIsEditorDirty(false);
   };
 
   if (!skill) {
@@ -379,7 +396,7 @@ export function SkillPage({
         assistantTriggerRef={assistantTriggerRef}
         frontmatterRepair={selectedFrontmatterRepair}
         onFixYaml={() => setIsFrontmatterRepairOpen(true)}
-        onEditManually={() => setIsEditing(true)}
+        onEditManually={startEditing}
       />
 
       <div className="flex min-w-0 flex-col gap-6">
@@ -401,14 +418,19 @@ export function SkillPage({
             onRetry={handleRetryLoad}
             editState={
               isEditing
-                ? { kind: "editing", isDirty: isEditorDirty, isSaving }
+                ? {
+                    kind: "editing",
+                    openedContent: editorOpenedContent,
+                    isDirty: isEditorDirty,
+                    isSaving,
+                  }
                 : { kind: "viewing" }
             }
-            onStartEdit={() => setIsEditing(true)}
+            onStartEdit={startEditing}
             saveLabel={needsForkToSave ? "Fork and save" : "Save"}
             onSave={handleSave}
             onCancelEdit={() => {
-              setIsEditing(false);
+              setEditorOpenedContent(null);
               setIsEditorDirty(false);
             }}
             onDirtyChange={setIsEditorDirty}
@@ -445,7 +467,7 @@ export function SkillPage({
           target={lifecycleTargetForDeployment(deployment)}
           preview={selectedFrontmatterRepair}
           onClose={() => setIsFrontmatterRepairOpen(false)}
-          onEditManually={() => setIsEditing(true)}
+          onEditManually={startEditing}
           onApplied={() => {
             setFrontmatterRepair(null);
             if (skillMdPath) loadContent(skillMdPath, false);

--- a/apps/desktop/src/components/SkillDetail/skill-editor-save.test.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-editor-save.test.ts
@@ -1,0 +1,55 @@
+// ============================================================================
+// Skill Studio - inline SKILL.md editor save tests
+// ============================================================================
+
+import { describe, expect, it, vi } from "vitest";
+import { saveSkillEditorDraft } from "./skill-editor-save";
+
+describe("saveSkillEditorDraft", () => {
+  it("does not overwrite a concurrent write when the editor baseline is stale", async () => {
+    let diskContent = "assistant update";
+    const writeIfUnchanged = vi.fn(
+      async (_path: string, expectedContent: string, content: string): Promise<void> => {
+        if (diskContent !== expectedContent) throw new Error("SKILL.md changed on disk");
+        diskContent = content;
+      },
+    );
+
+    await expect(
+      saveSkillEditorDraft(
+        {
+          path: "/skills/example/SKILL.md",
+          openedContent: "content when editor opened",
+          draftContent: "user draft",
+        },
+        writeIfUnchanged,
+      ),
+    ).rejects.toThrow("SKILL.md changed on disk");
+
+    expect(writeIfUnchanged).toHaveBeenCalledWith(
+      "/skills/example/SKILL.md",
+      "content when editor opened",
+      "user draft",
+    );
+    expect(diskContent).toBe("assistant update");
+  });
+
+  it("advances the baseline to the saved draft after a successful save", async () => {
+    const writeIfUnchanged = vi.fn(async (): Promise<void> => undefined);
+
+    const saved = await saveSkillEditorDraft(
+      {
+        path: "/skills/example/SKILL.md",
+        openedContent: "content when editor opened",
+        draftContent: "saved draft",
+      },
+      writeIfUnchanged,
+    );
+
+    expect(saved).toEqual({
+      path: "/skills/example/SKILL.md",
+      openedContent: "saved draft",
+      draftContent: "saved draft",
+    });
+  });
+});

--- a/apps/desktop/src/components/SkillDetail/skill-editor-save.ts
+++ b/apps/desktop/src/components/SkillDetail/skill-editor-save.ts
@@ -1,0 +1,20 @@
+// ============================================================================
+// Skill Studio - inline SKILL.md editor save
+// Keeps the editor-open baseline attached to each compare-and-swap write.
+// ============================================================================
+
+/** One inline editor draft and the exact file content from when editing started. */
+export interface SkillEditorDraft {
+  path: string;
+  openedContent: string;
+  draftContent: string;
+}
+
+/** Saves one editor draft with compare-and-swap and advances its baseline only after success. */
+export async function saveSkillEditorDraft(
+  draft: SkillEditorDraft,
+  writeIfUnchanged: (path: string, expectedContent: string, content: string) => Promise<void>,
+): Promise<SkillEditorDraft> {
+  await writeIfUnchanged(draft.path, draft.openedContent, draft.draftContent);
+  return { ...draft, openedContent: draft.draftContent };
+}

--- a/apps/desktop/src/lib/skill-api.ts
+++ b/apps/desktop/src/lib/skill-api.ts
@@ -162,19 +162,9 @@ export async function readInstalledSkillMd(path: string): Promise<string> {
 }
 
 /**
- * Overwrite an installed skill's `SKILL.md` with `content`, for the detail
- * drawer's inline editor. Refused when the file belongs to a plugin-managed
- * deployment or falls outside the current snapshot.
- */
-export async function writeInstalledSkillMd(path: string, content: string): Promise<void> {
-  return invoke("write_installed_skill_md", { path, content });
-}
-
-/**
- * Like `writeInstalledSkillMd`, but refuses (compare-and-swap) when the
- * file's current content doesn't match `expectedContent` - the copy the
- * caller last loaded. Used by the Audit proposal's Apply action so a save
- * made elsewhere while the proposal was open can't be silently clobbered.
+ * Overwrites an installed skill's `SKILL.md` only when its current content
+ * matches `expectedContent`. Audit proposal Apply and the inline editor use
+ * this compare-and-swap so a save made elsewhere can't be silently clobbered.
  */
 export async function writeInstalledSkillMdIfUnchanged(
   path: string,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5,7 +5,18 @@
 // ============================================================================
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { proxyGet, requireApiKey, upstreamUrl } from "./server";
+import {
+  createApp,
+  createNodeRequestHandler,
+  isAllowedRawRequestTarget,
+  proxyGet,
+  requireApiKey,
+  upstreamUrl,
+} from "./server";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("upstreamUrl", () => {
   it("appends the path and search string verbatim to the skills.sh base", () => {
@@ -20,10 +31,6 @@ describe("upstreamUrl", () => {
 });
 
 describe("proxyGet", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("sends the bearer token and relays the upstream's status and body", async () => {
     const fetchMock = vi
       .fn()
@@ -56,6 +63,120 @@ describe("proxyGet", () => {
 
     expect(result.status).toBe(502);
     expect(result.body).toEqual({ error: "getaddrinfo ENOTFOUND skills.sh" });
+  });
+});
+
+describe("GET /api/v1/skills/:owner/:repo/:slug", () => {
+  it.each([
+    "/api/v1/skills/%2E%2E/repo/slug",
+    "/api/v1/skills/owner/repo%2Fescape/slug",
+    "/api/v1/skills/owner/repo%252Fescape/slug",
+    "/api/v1/skills/owner/repo/%2E%2E",
+    "/api/v1/skills/owner/repo/%252E%252E",
+    "/api/v1/skills/owner/repo/skill%5Cname",
+    "/api/v1/skills/owner/repo/skill%255Cname",
+    "/api/v1/skills/owner/repo/%E0%A4%A",
+  ])("rejects unsafe encoded segments before fetch: %s", async (path) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await createApp("sk-secret").request(`http://localhost${path}`);
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("encodes decoded safe segments once and forwards the query", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ skill: "ok" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await createApp("sk-secret").request(
+      "http://localhost/api/v1/skills/org%20name/repo%2Btools/skill%25%40v1?ref=a%2Fb",
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://skills.sh/api/v1/skills/org%20name/repo%2Btools/skill%25%40v1?ref=a%2Fb",
+      { headers: { Authorization: "Bearer sk-secret" } },
+    );
+  });
+});
+
+describe("raw Node request target validation", () => {
+  it.each([
+    "/api/v1/skills/x/../search",
+    "/api/v1/skills/x/%2e%2e/search",
+    "/api/v1/skills/x/%252e%252e/search",
+    "/api/v1/skills/owner/repo%2Fescape/slug",
+    "/api/v1/skills/owner/repo%252Fescape/slug",
+    "/api/v1/skills/owner/repo/skill%5Cname",
+    "/api/v1/skills/owner/repo/skill%255Cname",
+    "/api/v1/skills/owner/repo/%E0%A4%A",
+    "/api/v1/skills/search?q=%E0%A4%A",
+  ])("rejects an unsafe raw path: %s", (rawTarget) => {
+    expect(isAllowedRawRequestTarget(rawTarget)).toBe(false);
+  });
+
+  it.each([
+    ["/api/v1/skills/x/../search", "/api/v1/skills/search"],
+    ["/api/v1/skills/x/%2e%2e/search", "/api/v1/skills/search"],
+    ["/api/v1/skills/x/%252e%252e/search", "/api/v1/skills/search"],
+    ["/api/v1/skills/search/%2e%2e", "/api/v1/skills"],
+  ])(
+    "rejects %s even when the Fetch Request has normalized to %s",
+    async (rawTarget, normalizedPath) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const handler = createNodeRequestHandler("sk-secret");
+      const normalizedRequest = new Request(`http://localhost${normalizedPath}`);
+      expect(new URL(normalizedRequest.url).pathname).toBe(normalizedPath);
+
+      const response = await handler(normalizedRequest, { incoming: { url: rawTarget } });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).not.toContain("sk-secret");
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "/api/v1/skills/owner/repo%2Fescape/slug",
+    "/api/v1/skills/owner/repo%252Fescape/slug",
+    "/api/v1/skills/owner/repo/skill%5Cname",
+    "/api/v1/skills/owner/repo/skill%255Cname",
+    "/api/v1/skills/owner/repo/%E0%A4%A",
+    "/api/v1/skills/search?q=%E0%A4%A",
+  ])("rejects %s at the production seam before bearer fetch", async (rawTarget) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const handler = createNodeRequestHandler("sk-secret");
+    const response = await handler(new Request("http://localhost/api/v1/skills"), {
+      incoming: { url: rawTarget },
+    });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "/api/v1/skills?view=all-time&page=0",
+    "/api/v1/skills/search?q=a%2Fb&limit=10",
+    "/api/v1/skills/org%20name/repo%2Btools/skill%25%40v1?ref=a%2Fb",
+  ])("allows an exact supported route: %s", async (rawTarget) => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const handler = createNodeRequestHandler("sk-secret");
+
+    const response = await handler(new Request(`http://localhost${rawTarget}`), {
+      incoming: { url: rawTarget },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -15,6 +15,12 @@ const UPSTREAM_BASE = "https://skills.sh/api/v1";
 const DEFAULT_PORT = 8787;
 const HOST = "127.0.0.1";
 
+interface RawNodeRequestEnvironment {
+  incoming: {
+    url?: string;
+  };
+}
+
 /** One proxied GET's outcome: the upstream's own status and JSON body when
  * it responded at all (any status, not just 2xx), or a synthetic `{ error }`
  * body when the request to skills.sh itself couldn't be made. */
@@ -64,6 +70,78 @@ export function requireApiKey(env: NodeJS.ProcessEnv): string {
   return key;
 }
 
+/** True only when no decoding layer turns a path segment into traversal or a separator. */
+function decodesToSafePathSegment(segment: string): boolean {
+  let decodedLayer = segment;
+  while (true) {
+    if (
+      decodedLayer.length === 0 ||
+      decodedLayer === "." ||
+      decodedLayer === ".." ||
+      decodedLayer.includes("/") ||
+      decodedLayer.includes("\\")
+    ) {
+      return false;
+    }
+    const nextLayer = decodedLayer.replace(/%([0-9a-f]{2})/gi, (_escape, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    );
+    if (nextLayer === decodedLayer) return true;
+    decodedLayer = nextLayer;
+  }
+}
+
+/** True only when a raw path segment has valid percent encoding and stays safe when decoded. */
+function isSafeRawPathSegment(segment: string): boolean {
+  try {
+    decodeURIComponent(segment);
+  } catch {
+    return false;
+  }
+  return decodesToSafePathSegment(segment);
+}
+
+/** Validates the unnormalized Node request target before Hono can route a normalized URL. */
+export function isAllowedRawRequestTarget(rawTarget: string | undefined): boolean {
+  if (!rawTarget) return false;
+
+  const queryStart = rawTarget.indexOf("?");
+  const rawPath = queryStart === -1 ? rawTarget : rawTarget.slice(0, queryStart);
+  const rawQuery = queryStart === -1 ? "" : rawTarget.slice(queryStart + 1);
+  try {
+    decodeURIComponent(rawQuery);
+  } catch {
+    return false;
+  }
+  const segments = rawPath.split("/");
+  if (segments[0] !== "" || segments.slice(1).some((segment) => !isSafeRawPathSegment(segment))) {
+    return false;
+  }
+
+  const isApiV1 = segments[1] === "api" && segments[2] === "v1";
+  if (!isApiV1) return true;
+
+  const isSkillsRoute = segments[3] === "skills";
+  const isListRoute = isSkillsRoute && segments.length === 4;
+  const isSearchRoute = isSkillsRoute && segments.length === 5 && segments[4] === "search";
+  const isDetailRoute = isSkillsRoute && segments.length === 7;
+  return isListRoute || isSearchRoute || isDetailRoute;
+}
+
+/** Detects malformed first-pass percent encoding before Hono's tolerant parameter decoding hides it. */
+function hasMalformedSkillDetailEncoding(url: string): boolean {
+  const encodedSegments = new URL(url).pathname.split("/").slice(4);
+  if (encodedSegments.length !== 3) return true;
+  return encodedSegments.some((segment) => {
+    try {
+      decodeURIComponent(segment);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}
+
 /** Builds the Hono app for `apiKey` - split out from `main` so tests can
  * exercise routes without starting a real listener. */
 export function createApp(apiKey: string): Hono {
@@ -94,23 +172,39 @@ export function createApp(apiKey: string): Hono {
 
   app.get("/api/v1/skills/:owner/:repo/:slug", async (c) => {
     const { owner, repo, slug } = c.req.param();
+    const segments = [owner, repo, slug];
+    if (hasMalformedSkillDetailEncoding(c.req.url) || !segments.every(decodesToSafePathSegment)) {
+      return c.json({ error: "Invalid skill detail path" }, 400);
+    }
     const { status, body } = await proxyGet(
       apiKey,
-      `/skills/${owner}/${repo}/${slug}`,
+      `/skills/${segments.map((segment) => encodeURIComponent(segment)).join("/")}`,
       new URL(c.req.url).search,
     );
     // SAFETY: see the /api/v1/skills handler above.
     return c.json(body, status as ContentfulStatusCode);
   });
 
+  app.get("/api/v1/*", (c) => c.json({ error: "Invalid skill detail path" }, 400));
+
   return app;
+}
+
+/** Creates the production Node fetch seam that rejects unsafe raw targets before Hono routing. */
+export function createNodeRequestHandler(apiKey: string) {
+  const app = createApp(apiKey);
+  return (request: Request, env: RawNodeRequestEnvironment): Response | Promise<Response> => {
+    if (!isAllowedRawRequestTarget(env.incoming.url)) {
+      return Response.json({ error: "Invalid request path" }, { status: 400 });
+    }
+    return app.fetch(request, env);
+  };
 }
 
 function main() {
   const apiKey = requireApiKey(process.env);
   const port = Number(process.env.PORT) || DEFAULT_PORT;
-  const app = createApp(apiKey);
-  serve({ fetch: app.fetch, port, hostname: HOST }, (info) => {
+  serve({ fetch: createNodeRequestHandler(apiKey), port, hostname: HOST }, (info) => {
     process.stdout.write(`Skill Studio server listening on http://${HOST}:${info.port}\n`);
   });
 }

--- a/packages/lib/src/skill-agent-prompts.test.ts
+++ b/packages/lib/src/skill-agent-prompts.test.ts
@@ -27,6 +27,21 @@ describe("fenceForMarkdown", () => {
 });
 
 describe("extractProposedSkillMd", () => {
+  it("honors the no-changes sentinel before unrelated fenced text", () => {
+    const finalText = `${HEADING}\n\nNo changes proposed.\n\n\`\`\`markdown\nunrelated\n\`\`\``;
+    expect(extractProposedSkillMd(finalText)).toBeNull();
+  });
+
+  it("does not treat a bare fenced snippet as a proposal", () => {
+    const finalText = `${HEADING}\n\n\`\`\`\nunrelated\n\`\`\``;
+    expect(extractProposedSkillMd(finalText)).toBeNull();
+  });
+
+  it("skips bare and other-language fences before a tagged proposal", () => {
+    const finalText = `${HEADING}\n\n\`\`\`\nunrelated before\n\`\`\`\n\n\`\`\`text\nstill unrelated\n\`\`\`\n\n~~~~md\n---\nname: proposed\n---\n~~~~\n\n\`\`\`\nunrelated after\n\`\`\``;
+    expect(extractProposedSkillMd(finalText)).toBe("---\nname: proposed\n---");
+  });
+
   it("extracts a proposal whose body contains a shorter ``` fence inside a longer outer fence", () => {
     const inner = "```js\nconsole.log(1);\n```";
     const finalText = `${HEADING}\n\n\`\`\`\`markdown\n---\nname: foo\n---\n\n${inner}\n\`\`\`\``;

--- a/packages/lib/src/skill-agent-prompts.ts
+++ b/packages/lib/src/skill-agent-prompts.ts
@@ -83,8 +83,8 @@ ${PROPOSED_HEADING}
 Only include this section if changes are worth making. If so, follow the heading with ONE fenced block wrapping the complete revised SKILL.md - frontmatter included, nothing omitted, no placeholders. Wrap the proposed file in a fence of exactly ${fence.length} backticks (${fence}markdown … ${fence}), because the file itself contains shorter fences. If no change is worth making, write "No changes proposed." instead of the block.`;
 }
 
-/** Matches a fenced code block (3+ backticks or 3+ tildes, optionally tagged \`markdown\`/\`md\`) and captures the opening fence, the info string line, and the body. */
-const FENCE_OPEN_RE = /^(`{3,}|~{3,})[ \t]*(?:markdown|md)?[ \t]*$/;
+/** Matches a fenced code block tagged exactly `markdown` or `md` and captures its opening fence. */
+const MARKDOWN_FENCE_OPEN_RE = /^(`{3,}|~{3,})[ \t]*(?:markdown|md)[ \t]*$/;
 
 /**
  * Pulls the fenced SKILL.md rewrite out of a finished run's `finalText`, if
@@ -102,12 +102,14 @@ export function extractProposedSkillMd(finalText: string): string | null {
   if (headingIndex === -1) return null;
   const afterHeading = finalText.slice(headingIndex + PROPOSED_HEADING.length);
   const lines = afterHeading.split(/\r\n|\n/);
+  const firstContentLine = lines.find((line) => line.trim().length > 0);
+  if (firstContentLine === "No changes proposed.") return null;
 
   let openerIndex = -1;
   let fenceChar = "";
   let fenceLength = 0;
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(FENCE_OPEN_RE);
+    const match = lines[i].match(MARKDOWN_FENCE_OPEN_RE);
     if (match) {
       openerIndex = i;
       fenceChar = match[1][0];


### PR DESCRIPTION
## Summary
- reject raw encoded and normalized traversal before authenticated skills.sh proxy fetches
- serialize app-managed SKILL.md read/check/write transactions and use editor-open compare-and-swap baselines
- preserve inline drafts on conflicts and coordinate frontmatter repair undo/redo
- accept only explicit markdown proposal fences and the no-change sentinel

## Verification
- Rust fmt, check, Clippy, and 657 tests
- server: 39 focused tests and typecheck
- desktop: 141 tests and typecheck
- shared lib: 148 tests
- scoped lint and format checks
- git diff check
- final independent review: no findings

Closes #20
Closes #21
Closes #31