### PR TITLE
fix: resolve skill discovery and targeting edge cases

### DIFF
--- a/apps/desktop/src-tauri/src/skills/frontmatter.rs
+++ b/apps/desktop/src-tauri/src/skills/frontmatter.rs
@@ -151,12 +151,17 @@ pub fn frontmatter_fields(content: &str) -> BTreeMap<String, String> {
         return BTreeMap::new();
     }
     let mut yaml_block = String::new();
+    let mut has_closing_fence = false;
     for line in lines {
         if line.trim() == "---" {
+            has_closing_fence = true;
             break;
         }
         yaml_block.push_str(line);
         yaml_block.push('\n');
+    }
+    if !has_closing_fence {
+        return BTreeMap::new();
     }
     let Ok(serde_yaml::Value::Mapping(map)) = serde_yaml::from_str(&yaml_block) else {
         return BTreeMap::new();
@@ -387,6 +392,25 @@ mod tests {
         assert_eq!(
             violations,
             vec!["invalid YAML frontmatter at line 4, column 1: unterminated YAML frontmatter"]
+        );
+    }
+
+    #[test]
+    fn frontmatter_fields_rejects_body_fields_after_an_unclosed_fence() {
+        let content = "---\nname: write-tests\ndescription: Writes tests.\ndisable-model-invocation: true\nRole: test author\nGoal: write tests for new features\n";
+
+        assert!(frontmatter_fields(content).is_empty());
+    }
+
+    #[test]
+    fn frontmatter_fields_parses_valid_crlf_frontmatter() {
+        let content = "---\r\nname: write-tests\r\ndescription: Writes tests.\r\n---\r\nBody.";
+        let fields = frontmatter_fields(content);
+
+        assert_eq!(fields.get("name").map(String::as_str), Some("write-tests"));
+        assert_eq!(
+            fields.get("description").map(String::as_str),
+            Some("Writes tests.")
         );
     }
 

--- a/apps/desktop/src-tauri/src/skills/project_discovery.rs
+++ b/apps/desktop/src-tauri/src/skills/project_discovery.rs
@@ -54,12 +54,44 @@ const MAX_TRANSCRIPT_LINE_BYTES: usize = 64 * 1024;
 /// lines could otherwise still cost an unbounded amount of I/O.
 const MAX_TRANSCRIPT_FILE_BYTES: u64 = 4 * 1024 * 1024;
 
-/// Newest transcript files tried per project dir before giving up on that
-/// project, and the total bytes one discovery run may read across every
-/// project. Together they bound one refresh even when no transcript carries
-/// a recognizable `cwd` (e.g. after a transcript schema change).
-const MAX_TRANSCRIPTS_PER_PROJECT: usize = 5;
+/// Total bytes one discovery run may read across every project. This bounds
+/// one refresh even when no transcript carries a recognizable `cwd` (e.g.
+/// after a transcript schema change).
 const MAX_TRANSCRIPT_TOTAL_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Transcript files one discovery run may try to open. This independently
+/// bounds empty and unreadable files, which do not consume the byte budget.
+const MAX_TRANSCRIPT_ATTEMPTS: usize = 10_000;
+
+struct TranscriptScanLimits {
+    remaining_bytes: u64,
+    remaining_attempts: usize,
+}
+
+impl TranscriptScanLimits {
+    fn new(remaining_bytes: u64, remaining_attempts: usize) -> Self {
+        Self {
+            remaining_bytes,
+            remaining_attempts,
+        }
+    }
+
+    fn can_attempt_transcript(&self) -> bool {
+        self.remaining_bytes > 0 && self.remaining_attempts > 0
+    }
+
+    fn begin_transcript_attempt(&mut self) -> Option<u64> {
+        if !self.can_attempt_transcript() {
+            return None;
+        }
+        self.remaining_attempts -= 1;
+        Some(MAX_TRANSCRIPT_FILE_BYTES.min(self.remaining_bytes))
+    }
+
+    fn consume_bytes(&mut self, bytes: u64) {
+        self.remaining_bytes = self.remaining_bytes.saturating_sub(bytes);
+    }
+}
 
 /// The `cwd` recorded in a single transcript file: the first line (of up to
 /// `MAX_TRANSCRIPT_LINES`, each capped at `MAX_TRANSCRIPT_LINE_BYTES`, within
@@ -68,14 +100,14 @@ const MAX_TRANSCRIPT_TOTAL_BYTES: u64 = 64 * 1024 * 1024;
 /// the per-line cap abandons the whole file rather than draining and
 /// continuing, so a single pathological line can't be used to keep reading
 /// past the file's budget one bounded chunk at a time.
-fn cwd_from_transcript(path: &Path, total_budget: &mut u64) -> Option<PathBuf> {
+fn cwd_from_transcript(path: &Path, limits: &mut TranscriptScanLimits) -> Option<PathBuf> {
+    let mut budget = limits.begin_transcript_attempt()?;
     let file = fs::File::open(path).ok()?;
     let mut reader = BufReader::new(file);
     // Reused across iterations and cleared each time, so memory use is
     // bounded by one line's worth of bytes rather than growing with the
     // number of lines scanned.
     let mut buf: Vec<u8> = Vec::new();
-    let mut budget = MAX_TRANSCRIPT_FILE_BYTES.min(*total_budget);
     for _ in 0..MAX_TRANSCRIPT_LINES {
         if budget == 0 {
             break;
@@ -91,7 +123,7 @@ fn cwd_from_transcript(path: &Path, total_budget: &mut u64) -> Option<PathBuf> {
             Ok(0) => break, // EOF
             Ok(n) => {
                 budget = budget.saturating_sub(n as u64);
-                *total_budget = total_budget.saturating_sub(n as u64);
+                limits.consume_bytes(n as u64);
             }
             Err(_) => break,
         }
@@ -124,23 +156,28 @@ fn cwd_from_transcript(path: &Path, total_budget: &mut u64) -> Option<PathBuf> {
     None
 }
 
-/// The `cwd` recorded in each Claude Code project's transcripts: for each
-/// dir in `~/.claude/projects/*`, scan its `*.jsonl` files newest-first and
-/// use the first one with a valid `cwd`.
+/// The distinct `cwd` values recorded in Claude Code project transcripts.
+/// Each encoded project directory can represent more than one real path, so
+/// every `*.jsonl` file is scanned newest-first within the total byte budget.
 fn claude_transcript_cwds(home: &Path) -> Vec<PathBuf> {
-    claude_transcript_cwds_within(home, MAX_TRANSCRIPT_TOTAL_BYTES)
+    claude_transcript_cwds_within(
+        home,
+        TranscriptScanLimits::new(MAX_TRANSCRIPT_TOTAL_BYTES, MAX_TRANSCRIPT_ATTEMPTS),
+    )
 }
 
-/// `claude_transcript_cwds` with an explicit operation-wide byte budget;
-/// stops scanning (returning what it found so far) once the budget is spent.
-fn claude_transcript_cwds_within(home: &Path, mut total_budget: u64) -> Vec<PathBuf> {
-    let mut out = Vec::new();
+/// `claude_transcript_cwds` with explicit operation-wide limits. Stops
+/// scanning and returns what it found when either limit is spent.
+fn claude_transcript_cwds_within(home: &Path, mut limits: TranscriptScanLimits) -> Vec<PathBuf> {
+    let mut out = BTreeSet::new();
 
     let Ok(project_dirs) = fs::read_dir(home.join(".claude/projects")) else {
-        return out;
+        return Vec::new();
     };
-    for project_dir in project_dirs.flatten() {
-        if total_budget == 0 {
+    let mut project_dirs: Vec<_> = project_dirs.flatten().collect();
+    project_dirs.sort_by_key(|entry| entry.path());
+    for project_dir in project_dirs {
+        if !limits.can_attempt_transcript() {
             break;
         }
         let dir = project_dir.path();
@@ -157,22 +194,30 @@ fn claude_transcript_cwds_within(home: &Path, mut total_budget: u64) -> Vec<Path
             // `*.jsonl` is never opened as a transcript.
             .filter(|e| fs::symlink_metadata(e.path()).is_ok_and(|m| m.file_type().is_file()))
             .collect();
-        transcripts.sort_by_key(|e| {
-            e.metadata()
+        transcripts.sort_by(|left, right| {
+            let left_modified = left
+                .metadata()
                 .and_then(|m| m.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH)
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            let right_modified = right
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            right_modified
+                .cmp(&left_modified)
+                .then_with(|| left.path().cmp(&right.path()))
         });
-        transcripts.reverse(); // newest first
-        transcripts.truncate(MAX_TRANSCRIPTS_PER_PROJECT);
 
-        if let Some(cwd) = transcripts
-            .iter()
-            .find_map(|e| cwd_from_transcript(&e.path(), &mut total_budget))
-        {
-            out.push(cwd);
+        for transcript in transcripts {
+            if !limits.can_attempt_transcript() {
+                break;
+            }
+            if let Some(cwd) = cwd_from_transcript(&transcript.path(), &mut limits) {
+                out.insert(cwd);
+            }
         }
     }
-    out
+    out.into_iter().collect()
 }
 
 /// True when `path` is inside Skill Studio's own scratch root - the assistant's
@@ -248,14 +293,53 @@ mod tests {
             fs::create_dir_all(home.join(format!("proj{i}/.claude/skills"))).unwrap();
         }
 
-        let unbounded = claude_transcript_cwds_within(home, u64::MAX);
+        let unbounded =
+            claude_transcript_cwds_within(home, TranscriptScanLimits::new(u64::MAX, usize::MAX));
         assert_eq!(unbounded.len(), 10);
 
-        let bounded = claude_transcript_cwds_within(home, 2_500);
+        let bounded =
+            claude_transcript_cwds_within(home, TranscriptScanLimits::new(2_500, usize::MAX));
         assert!(
             bounded.len() <= 3,
             "budget should stop the scan early: {bounded:?}"
         );
+    }
+
+    #[test]
+    fn empty_and_invalid_transcripts_exhaust_attempt_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let project = home.join("older-valid-project");
+        fs::create_dir_all(project.join(".claude/skills")).unwrap();
+
+        let transcript_dir = home.join(".claude/projects/-attempt-limit");
+        fs::create_dir_all(&transcript_dir).unwrap();
+        let valid = transcript_dir.join("oldest-valid.jsonl");
+        fs::write(
+            &valid,
+            format!(r#"{{"type":"user","cwd":"{}"}}"#, project.display()),
+        )
+        .unwrap();
+        let invalid = transcript_dir.join("middle-invalid.jsonl");
+        fs::write(&invalid, "not json\n").unwrap();
+        let empty = transcript_dir.join("newest-empty.jsonl");
+        fs::write(&empty, "").unwrap();
+
+        let now = SystemTime::now();
+        fs::File::open(&valid)
+            .unwrap()
+            .set_modified(now - std::time::Duration::from_secs(120))
+            .unwrap();
+        fs::File::open(&invalid)
+            .unwrap()
+            .set_modified(now - std::time::Duration::from_secs(60))
+            .unwrap();
+        fs::File::open(&empty).unwrap().set_modified(now).unwrap();
+
+        let limits = TranscriptScanLimits::new(u64::MAX, 2);
+        let found = claude_transcript_cwds_within(home, limits);
+
+        assert!(found.is_empty());
     }
 
     #[test]
@@ -278,6 +362,64 @@ mod tests {
 
         let found = discover_skill_projects(home);
         assert_eq!(found, vec![project]);
+    }
+
+    #[test]
+    fn colliding_claude_project_directory_discovers_every_transcript_cwd() {
+        fn claude_project_dir_name(path: &Path) -> String {
+            path.to_string_lossy()
+                .chars()
+                .map(|character| {
+                    if character.is_ascii_alphanumeric() {
+                        character
+                    } else {
+                        '-'
+                    }
+                })
+                .collect()
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let hyphenated_project = home.join("foo-bar");
+        let nested_project = home.join("foo/bar");
+        fs::create_dir_all(hyphenated_project.join(".claude/skills")).unwrap();
+        fs::create_dir_all(nested_project.join(".claude/skills")).unwrap();
+
+        let encoded_hyphenated = claude_project_dir_name(&hyphenated_project);
+        let encoded_nested = claude_project_dir_name(&nested_project);
+        assert_eq!(encoded_hyphenated, encoded_nested);
+
+        let transcript_dir = home.join(".claude/projects").join(encoded_hyphenated);
+        fs::create_dir_all(&transcript_dir).unwrap();
+        let older = transcript_dir.join("older.jsonl");
+        fs::write(
+            &older,
+            format!(
+                r#"{{"type":"user","cwd":"{}"}}"#,
+                nested_project.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        let newer = transcript_dir.join("newer.jsonl");
+        fs::write(
+            &newer,
+            format!(
+                r#"{{"type":"user","cwd":"{}"}}"#,
+                hyphenated_project.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let now = SystemTime::now();
+        fs::File::open(&older)
+            .unwrap()
+            .set_modified(now - std::time::Duration::from_secs(60))
+            .unwrap();
+        fs::File::open(&newer).unwrap().set_modified(now).unwrap();
+
+        let found = discover_skill_projects(home);
+        assert_eq!(found, vec![nested_project, hyphenated_project]);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/skills/skill_invocation.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_invocation.rs
@@ -18,12 +18,12 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::commands::{
-    canonicalize_skill_md, check_skill_md_write_allowed, require_snapshot_owns_path,
-};
+use super::commands::canonicalize_skill_md;
 use super::frontmatter::{invocation_policy, parse_frontmatter, InvocationPolicy};
+use super::skill_deployment::parse_deployment_id;
+use super::skill_dto::Deployment;
 use super::skill_md_write::begin_skill_md_write_transaction;
-use super::skill_refresh::{self, SkillRefreshState};
+use super::skill_refresh::{self, SkillRefreshState, SkillSnapshot};
 
 /// Strips a line's trailing terminator (`\r\n` or `\n`), if it has one - used
 /// to compare line *content* while the raw, terminator-included slice is kept
@@ -245,20 +245,19 @@ fn patch_codex_openai_yaml(skill_dir: &Path, user_only: bool) -> Result<(), Stri
 
 /// `set_skill_invocation`'s logic, taking the canonical `SKILL.md` path
 /// directly so it's testable without a Tauri `AppHandle` or a snapshot.
-/// `has_codex_deployment` gates the `agents/openai.yaml` sidecar patch -
-/// only meaningful for a skill actually deployed to Codex.
+/// `is_codex_deployment` gates the `agents/openai.yaml` sidecar patch.
 pub fn set_skill_invocation_with(
     canonical_skill_md: &Path,
     policy: InvocationPolicy,
-    has_codex_deployment: bool,
+    is_codex_deployment: bool,
 ) -> Result<(), String> {
-    set_skill_invocation_with_read_hook(canonical_skill_md, policy, has_codex_deployment, || {})
+    set_skill_invocation_with_read_hook(canonical_skill_md, policy, is_codex_deployment, || {})
 }
 
 fn set_skill_invocation_with_read_hook(
     canonical_skill_md: &Path,
     policy: InvocationPolicy,
-    has_codex_deployment: bool,
+    is_codex_deployment: bool,
     after_read: impl FnOnce(),
 ) -> Result<(), String> {
     let transaction = begin_skill_md_write_transaction()?;
@@ -268,13 +267,87 @@ fn set_skill_invocation_with_read_hook(
     transaction.replace_text(canonical_skill_md, &updated)?;
     drop(transaction);
 
-    if has_codex_deployment {
+    if is_codex_deployment {
         let skill_dir = canonical_skill_md
             .parent()
             .ok_or("SKILL.md has no parent directory")?;
         patch_codex_openai_yaml(skill_dir, policy == InvocationPolicy::UserOnly)?;
     }
     Ok(())
+}
+
+/// Resolves one invocation edit to its exact lexical deployment before the
+/// requested `SKILL.md` is canonicalized. This prevents separate deployment
+/// paths that resolve to one directory from losing their harness identity.
+fn exact_snapshot_invocation_deployment<'a>(
+    snapshot: &'a SkillSnapshot,
+    name: &str,
+    requested_skill_md: &Path,
+) -> Result<&'a Deployment, String> {
+    if requested_skill_md
+        .file_name()
+        .and_then(|file| file.to_str())
+        != Some("SKILL.md")
+    {
+        return Err(format!(
+            "Invocation target is stale: {} is not a SKILL.md path",
+            requested_skill_md.display()
+        ));
+    }
+    let requested_dir = requested_skill_md.parent().ok_or_else(|| {
+        format!(
+            "Invocation target is stale: {} has no deployment directory",
+            requested_skill_md.display()
+        )
+    })?;
+    let mut matching = snapshot.skills.iter().flat_map(|skill| {
+        skill
+            .deployments
+            .iter()
+            .filter(move |deployment| Path::new(&deployment.path) == requested_dir)
+            .map(move |deployment| (skill, deployment))
+    });
+    let (skill, deployment) = matching.next().ok_or_else(|| {
+        format!(
+            "Invocation target is stale: {} is not an exact deployment in the current snapshot",
+            requested_skill_md.display()
+        )
+    })?;
+    if matching.next().is_some() {
+        return Err(format!(
+            "Invocation target is ambiguous: {} matches more than one deployment",
+            requested_skill_md.display()
+        ));
+    }
+    if skill.name != name {
+        return Err(format!(
+            "Invocation target is stale: {} belongs to {}, not {name}",
+            requested_skill_md.display(),
+            skill.name
+        ));
+    }
+
+    let parsed = parse_deployment_id(&deployment.id).ok_or_else(|| {
+        format!(
+            "Invocation target is stale: deployment {} has an invalid identity",
+            deployment.id
+        )
+    })?;
+    let codex_identity_mismatch = (parsed.slot == "codex") != (deployment.agent == "Codex");
+    if parsed.name != skill.name
+        || parsed.scope != deployment.scope
+        || parsed.destination != deployment.destination
+        || parsed.project_path != deployment.project_path
+        || parsed.lexical_path != Path::new(&deployment.path)
+        || codex_identity_mismatch
+    {
+        return Err(format!(
+            "Invocation target is stale: deployment {} no longer matches its snapshot identity",
+            deployment.id
+        ));
+    }
+
+    Ok(deployment)
 }
 
 #[tauri::command]
@@ -286,17 +359,20 @@ pub fn set_skill_invocation(
     refresh_state: tauri::State<SkillRefreshState>,
 ) -> Result<(), String> {
     let path_buf = PathBuf::from(&path);
-    require_snapshot_owns_path(&refresh_state, &path_buf)?;
+    let snapshot = refresh_state
+        .snapshot
+        .read()
+        .map_err(|error| format!("Snapshot lock poisoned: {error}"))?
+        .clone()
+        .ok_or_else(|| format!("Invocation target is stale: {path} is not an installed skill"))?;
+    let deployment = exact_snapshot_invocation_deployment(&snapshot, &name, &path_buf)?;
+    if deployment.plugin.is_some() {
+        return Err("Skill is managed by a plugin and cannot be edited here".to_string());
+    }
+    let is_codex_deployment = deployment.agent == "Codex";
     let canonical = canonicalize_skill_md(&path_buf, &path)?;
 
-    let snapshot = refresh_state.snapshot.read().ok().and_then(|g| g.clone());
-    check_skill_md_write_allowed(snapshot.as_ref(), &path_buf)?;
-    let has_codex_deployment = snapshot
-        .as_ref()
-        .and_then(|s| s.skills.iter().find(|s| s.name == name))
-        .is_some_and(|s| s.deployments.iter().any(|d| d.agent == "Codex"));
-
-    let result = set_skill_invocation_with(&canonical, policy, has_codex_deployment);
+    let result = set_skill_invocation_with(&canonical, policy, is_codex_deployment);
     if result.is_ok() {
         if let Err(error) =
             skill_refresh::reconcile_skill_names_and_emit(&app, &refresh_state, [name], &[])
@@ -311,6 +387,87 @@ pub fn set_skill_invocation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn invocation_snapshot(deployments: Vec<Deployment>) -> SkillSnapshot {
+        use super::super::provenance::SourceKind;
+        use super::super::skill_dto::InstalledSkill;
+        use super::super::skill_invocations::InvocationHeatmap;
+
+        SkillSnapshot {
+            revision: 1,
+            skills: vec![InstalledSkill {
+                name: "find-bugs".to_string(),
+                source: "manual".to_string(),
+                source_type: "manual".to_string(),
+                source_url: None,
+                skill_path: None,
+                installed_at: "2024-01-01T00:00:00Z".to_string(),
+                updated_at: None,
+                has_update: false,
+                update_owner_ids: Vec::new(),
+                update_owners: Vec::new(),
+                update_commit: None,
+                update_commit_at: None,
+                source_kind: SourceKind::Manual,
+                deployments,
+                has_spec: false,
+                description: None,
+                spec_violations: Vec::new(),
+                skill_md_tokens: 0,
+                description_tokens: 0,
+                folder_bytes: 0,
+                file_count: 0,
+                content_hash: String::new(),
+                content_hashes: Vec::new(),
+                modified_at: None,
+                frontmatter_fields: Default::default(),
+                folder_truncated: false,
+                fork: None,
+                trial: None,
+                trials: Vec::new(),
+                parked: false,
+                parked_at: None,
+                invocation: InvocationPolicy::Both,
+            }],
+            projects: Vec::new(),
+            invocations: Vec::new(),
+            heatmap: InvocationHeatmap::default(),
+            scanned_at: "2024-01-01T00:00:00Z".to_string(),
+            last_test_by_skill: Default::default(),
+            update_check: Default::default(),
+            opencode_config_kind: None,
+        }
+    }
+
+    fn invocation_deployment(
+        path: &Path,
+        agent: &str,
+        slot: &str,
+        destination: super::super::skill_deployment::SkillDestination,
+    ) -> Deployment {
+        use super::super::skill_deployment::{deployment_id, DeploymentMutability};
+
+        Deployment {
+            id: deployment_id("find-bugs", "global", destination, slot, None, path),
+            destination,
+            mutability: DeploymentMutability::Mutable,
+            agent: agent.to_string(),
+            scope: "global".to_string(),
+            path: path.to_string_lossy().into_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn write_invocation_skill(skill_dir: &Path) -> PathBuf {
+        fs::create_dir_all(skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        fs::write(
+            &skill_md,
+            "---\nname: find-bugs\ndescription: test\n---\nBody.",
+        )
+        .unwrap();
+        skill_md
+    }
 
     #[test]
     fn both_removes_either_key() {
@@ -448,6 +605,131 @@ mod tests {
         assert!(yaml.contains("other_key: kept"));
         assert!(yaml.contains("something_else: true"));
         assert!(yaml.contains("allow_implicit_invocation: false"));
+    }
+
+    #[test]
+    fn same_named_codex_sibling_does_not_create_a_claude_sidecar() {
+        use super::super::skill_deployment::SkillDestination;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude/skills/find-bugs");
+        let codex_dir = tmp.path().join(".codex/skills/find-bugs");
+        let claude_skill_md = write_invocation_skill(&claude_dir);
+        write_invocation_skill(&codex_dir);
+        let snapshot = invocation_snapshot(vec![
+            invocation_deployment(
+                &claude_dir,
+                "Claude Code",
+                "claude-code",
+                SkillDestination::PerHarness,
+            ),
+            invocation_deployment(&codex_dir, "Codex", "codex", SkillDestination::PerHarness),
+        ]);
+
+        let deployment =
+            exact_snapshot_invocation_deployment(&snapshot, "find-bugs", &claude_skill_md).unwrap();
+        set_skill_invocation_with(
+            &claude_skill_md,
+            InvocationPolicy::UserOnly,
+            deployment.agent == "Codex",
+        )
+        .unwrap();
+
+        assert!(!codex_openai_yaml_path(&claude_dir).exists());
+        assert!(!codex_openai_yaml_path(&codex_dir).exists());
+    }
+
+    #[test]
+    fn exact_codex_deployment_keeps_sidecar_behavior_with_same_named_sibling() {
+        use super::super::skill_deployment::SkillDestination;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude/skills/find-bugs");
+        let codex_dir = tmp.path().join(".codex/skills/find-bugs");
+        write_invocation_skill(&claude_dir);
+        let codex_skill_md = write_invocation_skill(&codex_dir);
+        let snapshot = invocation_snapshot(vec![
+            invocation_deployment(
+                &claude_dir,
+                "Claude Code",
+                "claude-code",
+                SkillDestination::PerHarness,
+            ),
+            invocation_deployment(&codex_dir, "Codex", "codex", SkillDestination::PerHarness),
+        ]);
+
+        let deployment =
+            exact_snapshot_invocation_deployment(&snapshot, "find-bugs", &codex_skill_md).unwrap();
+        set_skill_invocation_with(
+            &codex_skill_md,
+            InvocationPolicy::UserOnly,
+            deployment.agent == "Codex",
+        )
+        .unwrap();
+
+        let yaml = fs::read_to_string(codex_openai_yaml_path(&codex_dir)).unwrap();
+        assert!(yaml.contains("allow_implicit_invocation: false"));
+        assert!(!codex_openai_yaml_path(&claude_dir).exists());
+    }
+
+    #[test]
+    fn universal_deployment_with_a_codex_link_does_not_receive_a_sidecar() {
+        use super::super::skill_deployment::{BackingRelationship, SkillDestination};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let universal_dir = tmp.path().join(".agents/skills/find-bugs");
+        let codex_dir = tmp.path().join(".codex/skills/find-bugs");
+        let universal_skill_md = write_invocation_skill(&universal_dir);
+        let universal = invocation_deployment(
+            &universal_dir,
+            "shared",
+            "universal",
+            SkillDestination::Universal,
+        );
+        let mut codex_link =
+            invocation_deployment(&codex_dir, "Codex", "codex", SkillDestination::Universal);
+        codex_link.is_symlink = true;
+        codex_link.backing = BackingRelationship::LinkedTo {
+            deployment_id: universal.id.clone(),
+        };
+        let snapshot = invocation_snapshot(vec![universal, codex_link]);
+
+        let deployment =
+            exact_snapshot_invocation_deployment(&snapshot, "find-bugs", &universal_skill_md)
+                .unwrap();
+        set_skill_invocation_with(
+            &universal_skill_md,
+            InvocationPolicy::UserOnly,
+            deployment.agent == "Codex",
+        )
+        .unwrap();
+
+        assert!(!codex_openai_yaml_path(&universal_dir).exists());
+    }
+
+    #[test]
+    fn exact_invocation_deployment_rejects_stale_name_and_ambiguous_path() {
+        use super::super::skill_deployment::SkillDestination;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude/skills/find-bugs");
+        let skill_md = write_invocation_skill(&claude_dir);
+        let deployment = invocation_deployment(
+            &claude_dir,
+            "Claude Code",
+            "claude-code",
+            SkillDestination::PerHarness,
+        );
+        let snapshot = invocation_snapshot(vec![deployment.clone()]);
+
+        let stale =
+            exact_snapshot_invocation_deployment(&snapshot, "other-name", &skill_md).unwrap_err();
+        assert!(stale.contains("stale"));
+
+        let ambiguous = invocation_snapshot(vec![deployment.clone(), deployment]);
+        let error =
+            exact_snapshot_invocation_deployment(&ambiguous, "find-bugs", &skill_md).unwrap_err();
+        assert!(error.contains("ambiguous"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/skills/skill_run_history.rs
+++ b/apps/desktop/src-tauri/src/skills/skill_run_history.rs
@@ -135,16 +135,24 @@ fn record_run_at(
             .map_err(|e| format!("Could not write last.json: {e}"))?;
     }
 
-    trim_run_history(root, &dir, MAX_RUNS_PER_SKILL)?;
+    trim_run_history(root, &dir, MAX_RUNS_PER_SKILL, &record.id)?;
     Ok(())
 }
 
 /// Deletes the oldest `.json`/`.events.jsonl` record pairs in `dir` beyond
-/// `keep`, ordered by the record id (a run id, always chronological because
-/// it's the same UUID v4/v7-ish token the frontend generates per run start -
-/// sorted lexically by file mtime instead, which is monotonic regardless of
-/// the id's own shape).
-fn trim_run_history(root: &Path, dir: &Path, keep: usize) -> Result<(), String> {
+/// `keep`, ordered by file mtime because frontend UUID v4 run ids are not
+/// chronological. `protected_run_id` is excluded from deletion so a backward
+/// clock jump cannot make a newly written run delete itself.
+fn trim_run_history(
+    root: &Path,
+    dir: &Path,
+    keep: usize,
+    protected_run_id: &str,
+) -> Result<(), String> {
+    if keep == 0 {
+        return Err("Run history retention must keep at least one record".to_string());
+    }
+
     // Defense in depth: `validate_skill_dir_name` already keeps `dir` a
     // single path segment under `root`, but this is the call that deletes
     // files, so it re-checks containment against the canonical paths before
@@ -175,16 +183,27 @@ fn trim_run_history(root: &Path, dir: &Path, keep: usize) -> Result<(), String> 
             Some((modified, entry.path()))
         })
         .collect();
-    records.sort_by_key(|(modified, _)| *modified);
+    records.sort_by(|(left_modified, left_path), (right_modified, right_path)| {
+        left_modified
+            .cmp(right_modified)
+            .then_with(|| left_path.cmp(right_path))
+    });
 
-    if records.len() > keep {
-        for (_, path) in &records[..records.len() - keep] {
-            let _ = fs::remove_file(path);
-            if let Some(stem) = path.file_stem() {
-                let events_path =
-                    path.with_file_name(format!("{}.events.jsonl", stem.to_string_lossy()));
-                let _ = fs::remove_file(events_path);
-            }
+    let remove_count = records.len().saturating_sub(keep);
+    for (_, path) in records
+        .iter()
+        .filter(|(_, path)| {
+            path.file_stem()
+                .map(|stem| stem != protected_run_id)
+                .unwrap_or(true)
+        })
+        .take(remove_count)
+    {
+        let _ = fs::remove_file(path);
+        if let Some(stem) = path.file_stem() {
+            let events_path =
+                path.with_file_name(format!("{}.events.jsonl", stem.to_string_lossy()));
+            let _ = fs::remove_file(events_path);
         }
     }
     Ok(())
@@ -272,6 +291,7 @@ pub fn read_last_test_index(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::SystemTime;
     use tempfile::tempdir;
 
     fn sample_record(id: &str, started_at: &str) -> SkillRunRecord {
@@ -311,7 +331,7 @@ mod tests {
             fs::write(dir.path().join(format!("run-{i}.events.jsonl")), "").unwrap();
             std::thread::sleep(std::time::Duration::from_millis(5));
         }
-        trim_run_history(dir.path(), dir.path(), 2).unwrap();
+        trim_run_history(dir.path(), dir.path(), 2, "run-4").unwrap();
 
         let remaining: Vec<_> = fs::read_dir(dir.path())
             .unwrap()
@@ -319,6 +339,65 @@ mod tests {
             .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
             .collect();
         assert_eq!(remaining.len(), 2);
+    }
+
+    #[test]
+    fn trim_run_history_protects_the_just_written_oldest_run() {
+        let dir = tempdir().unwrap();
+        let write_record_pair = |id: &str, modified: SystemTime| {
+            let record = sample_record(id, "2024-01-01T00:00:00Z");
+            let record_path = dir.path().join(format!("{id}.json"));
+            let events_path = dir.path().join(format!("{id}.events.jsonl"));
+            fs::write(&record_path, serde_json::to_vec(&record).unwrap()).unwrap();
+            fs::write(&events_path, "event").unwrap();
+            fs::File::open(&record_path)
+                .unwrap()
+                .set_modified(modified)
+                .unwrap();
+        };
+
+        let first_mtime = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(10);
+        write_record_pair("protected", first_mtime);
+        write_record_pair(
+            "eligible-oldest",
+            first_mtime + std::time::Duration::from_secs(1),
+        );
+        write_record_pair(
+            "eligible-middle",
+            first_mtime + std::time::Duration::from_secs(2),
+        );
+        write_record_pair(
+            "eligible-newest",
+            first_mtime + std::time::Duration::from_secs(3),
+        );
+
+        trim_run_history(dir.path(), dir.path(), 2, "protected").unwrap();
+
+        assert!(dir.path().join("protected.json").is_file());
+        assert!(dir.path().join("protected.events.jsonl").is_file());
+        assert!(!dir.path().join("eligible-oldest.json").exists());
+        assert!(!dir.path().join("eligible-oldest.events.jsonl").exists());
+        assert!(!dir.path().join("eligible-middle.json").exists());
+        assert!(dir.path().join("eligible-newest.json").is_file());
+        let remaining_records = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
+            .count();
+        assert_eq!(remaining_records, 2);
+    }
+
+    #[test]
+    fn trim_run_history_rejects_zero_retention_without_deleting_records() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("protected.json"), "{}").unwrap();
+        fs::write(dir.path().join("protected.events.jsonl"), "event").unwrap();
+
+        let error = trim_run_history(dir.path(), dir.path(), 0, "protected").unwrap_err();
+
+        assert!(error.contains("at least one"));
+        assert!(dir.path().join("protected.json").is_file());
+        assert!(dir.path().join("protected.events.jsonl").is_file());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- discover every Claude transcript cwd when encoded project directory names collide, within byte and attempt budgets
- target invocation sidecars from the exact edited deployment
- reject dashboard fields from unterminated frontmatter
- protect newly recorded runs from backward-clock history trimming

## Verification
- 667 Rust tests
- cargo fmt and check
- Clippy with warnings denied
- git diff check
- final independent review: no findings

Closes #7
Closes #25
Closes #27
Closes #28