### PR TITLE
fix: classify generic interface dictionaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "fmt:rust": "cd apps/desktop/src-tauri && cargo fmt",
-    "test": "npm run test -w skill-studio && npm run test -w @skill-studio/lib && npm run test -w @skill-studio/server && npm run test -w @skill-studio/marketing",
+    "test": "npm run test:anti-slop && npm run test -w skill-studio && npm run test -w @skill-studio/lib && npm run test -w @skill-studio/server && npm run test -w @skill-studio/marketing",
+    "test:anti-slop": "vitest run tools/oxlint/anti-slop/shared/dictionary-types.integration.test.ts",
     "check": "npm run typecheck && npm run lint && npm run format:check && npm run doctor && npm run test && cd apps/desktop/src-tauri && cargo fmt --check && cargo clippy -- -D warnings && cargo test",
     "doctor": "react-doctor apps/desktop -y --no-score --no-supply-chain --blocking warning"
   },

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -76,8 +76,35 @@ function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironme
 	return !isInsideTypeAliasDeclaration(node);
 }
 
+function isPlainInterfaceConsumerWithReportedDefinition(
+	node: ESTree.TSType,
+	environment: TypeEnvironment,
+): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	if (name === null) return false;
+	const declarations = environment.interfaces.get(name);
+	if (
+		declarations === undefined ||
+		declarations.some((declaration) => (declaration.typeParameters?.params.length ?? 0) > 0)
+	)
+		return false;
+	return declarations.some((declaration) =>
+		declaration.body.body.some(
+			(member) =>
+				member.type === "TSIndexSignature" &&
+				member.typeAnnotation !== null &&
+				classifyUnsafeDictionaryValue(member.typeAnnotation.typeAnnotation, environment) !== null,
+		),
+	);
+}
+
 function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
-	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (
+		isPlainAliasConsumerUse(node, environment) ||
+		isPlainInterfaceConsumerWithReportedDefinition(node, environment)
+	)
+		return false;
 	if (classifyUnsafeDictionary(node, environment) === null) return false;
 	let current: ESTree.Node | null = node.parent;
 	while (current !== null && current.type !== "Program") {

--- a/tools/oxlint/anti-slop/shared/dictionary-types.integration.test.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.integration.test.ts
@@ -1,0 +1,655 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+interface OxlintJsonDiagnostic {
+	readonly code: string;
+	readonly message: string;
+}
+
+const oxlintJsonOutputSchema = z.object({
+	diagnostics: z.array(z.object({ code: z.string(), message: z.string() })),
+});
+
+function parseOxlintDiagnostics(stdout: string): readonly OxlintJsonDiagnostic[] {
+	return oxlintJsonOutputSchema.parse(JSON.parse(stdout)).diagnostics;
+}
+
+function lintAntiSlopFixture(
+	source: string,
+	rules: readonly string[],
+): readonly OxlintJsonDiagnostic[] {
+	const fixtureDirectory = mkdtempSync(join(tmpdir(), "anti-slop-dictionary-types-"));
+	const fixturePath = join(fixtureDirectory, "fixture.ts");
+	const configPath = join(fixtureDirectory, "oxlint.json");
+	writeFileSync(fixturePath, source);
+	writeFileSync(
+		configPath,
+		JSON.stringify({
+			categories: { correctness: "off" },
+			jsPlugins: [
+				{
+					name: "anti-slop",
+					specifier: resolve("tools/oxlint/anti-slop/index.ts"),
+				},
+			],
+			rules: Object.fromEntries(rules.map((rule) => [`anti-slop/${rule}`, "error"])),
+		}),
+	);
+
+	try {
+		const result = spawnSync(
+			resolve("node_modules/.bin/oxlint"),
+			["--config", configPath, "--format", "json", fixturePath],
+			{ encoding: "utf8", timeout: 10_000 },
+		);
+		if (result.error !== undefined) throw result.error;
+		if (result.status !== 0 && result.status !== 1) {
+			throw new Error(`Anti-slop Oxlint fixture failed: ${result.stderr || result.stdout}`);
+		}
+		return parseOxlintDiagnostics(result.stdout).filter((diagnostic) =>
+			diagnostic.code.startsWith("anti-slop("),
+		);
+	} finally {
+		rmSync(fixtureDirectory, { recursive: true, force: true });
+	}
+}
+
+function diagnosticCount(diagnostics: readonly OxlintJsonDiagnostic[], code: string): number {
+	return diagnostics.filter((diagnostic) => diagnostic.code === `anti-slop(${code})`).length;
+}
+
+describe("anti-slop interface dictionary rules", () => {
+	it("binds unknown, any, and default generic interface arguments", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface GenericDictionary<Value> {
+				[key: string]: Value;
+			}
+			interface DefaultDictionary<Value = unknown> {
+				[key: string]: Value;
+			}
+			const unknownDictionary: GenericDictionary<unknown> = {};
+			const anyDictionary: GenericDictionary<any> = {};
+			const defaultDictionary: DefaultDictionary = {};
+			const safeDictionary: GenericDictionary<string> = {};
+			void unknownDictionary;
+			void anyDictionary;
+			void defaultDictionary;
+			void safeDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(3);
+		expect(diagnostics.filter((diagnostic) => diagnostic.message.includes("unknown"))).toHaveLength(
+			2,
+		);
+		expect(diagnostics.filter((diagnostic) => diagnostic.message.includes("any"))).toHaveLength(1);
+	});
+
+	it("flags known evidence assigned and asserted to a generic interface dictionary", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface GenericDictionary<Value> {
+				[key: string]: Value;
+			}
+			interface OpenDictionary {
+				[key: string]: string;
+			}
+			const assigned: GenericDictionary<unknown> = { known: "value" };
+			const asserted = { known: "value" } as GenericDictionary<unknown>;
+			const openDictionary: OpenDictionary = { known: "value" };
+			void assigned;
+			void asserted;
+			void openDictionary;`,
+			["no-known-value-widening"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-known-value-widening")).toBe(3);
+		expect(
+			diagnostics.filter((diagnostic) => diagnostic.message.includes("generic container")),
+		).toHaveLength(2);
+		expect(
+			diagnostics.filter((diagnostic) => diagnostic.message.includes("open dictionary")),
+		).toHaveLength(1);
+	});
+
+	it("classifies generic and plain alias wrappers around interface dictionaries", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface GenericDictionary<Value> {
+				[key: string]: Value;
+			}
+			type GenericWrapper<Value> = GenericDictionary<Value>;
+			type PlainWrapper = GenericDictionary<string>;
+			const genericWrapper: GenericWrapper<unknown> = { known: "value" };
+			const plainWrapper: PlainWrapper = { known: "value" };
+			void genericWrapper;
+			void plainWrapper;`,
+			["no-unsafe-dictionary-type", "no-known-value-widening"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(1);
+		expect(diagnosticCount(diagnostics, "no-known-value-widening")).toBe(2);
+		expect(
+			diagnostics.filter((diagnostic) => diagnostic.message.includes("generic container")),
+		).toHaveLength(1);
+		expect(
+			diagnostics.filter((diagnostic) => diagnostic.message.includes("open dictionary")),
+		).toHaveLength(1);
+	});
+
+	it("collects substituted inherited and merged interface index signatures", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface BaseDictionary<Value> {
+				[key: string]: Value;
+			}
+			interface InheritedDictionary<Payload> extends BaseDictionary<Payload> {}
+			interface MergedDictionary<Value> {
+				label?: string;
+			}
+			interface MergedDictionary<Value> {
+				[key: string]: Value;
+			}
+			const inheritedUnsafe: InheritedDictionary<unknown> = {};
+			const inheritedSafe: InheritedDictionary<string> = {};
+			const mergedUnsafe: MergedDictionary<unknown> = {};
+			void inheritedUnsafe;
+			void inheritedSafe;
+			void mergedUnsafe;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(2);
+	});
+
+	it("binds explicit heritage arguments in the caller scope", () => {
+		const unsafeDiagnostics = lintAntiSlopFixture(
+			`interface Base<A, B> {
+				[key: string]: B;
+			}
+			interface Derived<A, B> extends Base<B, A> {}
+			const dictionary: Derived<unknown, string> = {};
+			void dictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+		const safeDiagnostics = lintAntiSlopFixture(
+			`interface Base<A, B> {
+				[key: string]: B;
+			}
+			interface Derived<A, B> extends Base<B, A> {}
+			const dictionary: Derived<string, unknown> = {};
+			void dictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(unsafeDiagnostics, "no-unsafe-dictionary-type")).toBe(1);
+		expect(safeDiagnostics).toEqual([]);
+	});
+
+	it("keeps a caller Readonly parameter out of the base interface scope", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface Base<Value> {
+				[key: string]: Readonly<Value>;
+			}
+			interface Derived<Readonly> extends Base<string> {}
+			const dictionary: Derived<unknown> = {};
+			void dictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("keeps a caller parameter out of the base interface global-alias scope", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type GlobalValue = string;
+			interface Base {
+				[key: string]: GlobalValue;
+			}
+			interface Derived<GlobalValue> extends Base {}
+			const dictionary: Derived<unknown> = {};
+			void dictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("preserves caller substitutions inside nested heritage arguments", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface Base<Value> {
+				[key: string]: Value;
+			}
+			interface Derived<Value> extends Base<Readonly<Value>> {}
+			const dictionary: Derived<unknown> = {};
+			void dictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(1);
+		expect(diagnostics[0]?.message).toContain("unknown");
+	});
+
+	it("resolves same-named caller arguments through their saved scopes", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			type AliasDictionary<Value> = Record<string, Value>;
+			interface InterfaceDictionary<Value> extends Record<string, Value> {}
+			const aliasDictionary: AliasDictionary<Value> = {};
+			const interfaceDictionary: InterfaceDictionary<Value> = {};
+			void aliasDictionary;
+			void interfaceDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(2);
+		expect(diagnostics.every((diagnostic) => diagnostic.message.includes("unknown"))).toBe(true);
+	});
+
+	it("keeps generic function parameters unresolved in nested lexical scopes", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			type OuterValue = unknown;
+			interface Dictionary<Entry> {
+				[key: string]: Entry;
+			}
+			function consumeDeclaration<Value>(input: Dictionary<Value>) {
+				void input;
+			}
+			const consumeExpression = function <Value>(input: Dictionary<Value>) {
+				void input;
+			};
+			const consumeArrow = <Value>(input: Dictionary<Value>) => void input;
+			declare function consumeDeclared<Value>(input: Dictionary<Value>): void;
+			function consumeOverload<Value>(input: Dictionary<Value>): void;
+			function consumeOverload(input: Dictionary<string>): void {
+				void input;
+			}
+			function consumeOuter<OuterValue>() {
+				return <InnerValue>(input: Dictionary<OuterValue>) => void input;
+			}
+			function consumeBuiltIn<Record>(input: Dictionary<Record>) {
+				void input;
+			}
+			void consumeDeclaration;
+			void consumeExpression;
+			void consumeArrow;
+			void consumeDeclared;
+			void consumeOverload;
+			void consumeOuter;
+			void consumeBuiltIn;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("keeps generic class parameters unresolved in class declarations and expressions", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			type MethodValue = unknown;
+			interface Dictionary<Entry> {
+				[key: string]: Entry;
+			}
+			class DictionaryOwner<Value> {
+				declare entries: Dictionary<Value>;
+				consume(input: Dictionary<Value>) {
+					void input;
+				}
+				consumeGeneric<MethodValue>(input: Dictionary<MethodValue>) {
+					void input;
+				}
+			}
+			const DictionaryOwnerExpression = class<Value> {
+				declare entries: Dictionary<Value>;
+			};
+			void DictionaryOwner;
+			void DictionaryOwnerExpression;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("keeps signature type parameters unresolved on their owning AST nodes", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			interface Dictionary<Entry> {
+				[key: string]: Entry;
+			}
+			interface GenericSignatures {
+				<Value>(input: Dictionary<Value>): void;
+				new <Value>(input: Dictionary<Value>): object;
+				consume<Value>(input: Dictionary<Value>): void;
+			}
+			type GenericFunction = <Value>(input: Dictionary<Value>) => void;
+			type GenericConstructor = new <Value>(input: Dictionary<Value>) => object;
+			abstract class AbstractConsumer {
+				abstract consume<Value>(input: Dictionary<Value>): void;
+			}
+			let signatures: GenericSignatures;
+			let genericFunction: GenericFunction;
+			let genericConstructor: GenericConstructor;
+			void signatures;
+			void genericFunction;
+			void genericConstructor;
+			void AbstractConsumer;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("reports concrete alias instantiations outside generic lexical scopes", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			interface Dictionary<Entry> {
+				[key: string]: Entry;
+			}
+			function consume<Value>(input: Dictionary<Value>) {
+				void input;
+			}
+			const concreteDictionary: Dictionary<Value> = {};
+			void consume;
+			void concreteDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(1);
+		expect(diagnostics[0]?.message).toContain("unknown");
+	});
+
+	it("keeps a caller PropertyKey parameter out of mapped alias widening scope", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type BaseDictionary = { [Key in PropertyKey]: string };
+			type DerivedDictionary<PropertyKey> = BaseDictionary;
+			type ConcreteDictionary = DerivedDictionary<"known">;
+			const dictionary: ConcreteDictionary = { known: "value" };
+			void dictionary;`,
+			["no-known-value-widening"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-known-value-widening")).toBe(1);
+		expect(diagnostics[0]?.message).toContain("open dictionary");
+	});
+
+	it("keeps a mapped key parameter out of its value's global alias scope", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Key = unknown;
+			type SafeMappedDictionary = { [Key in "known"]: Key };
+			const dictionary: SafeMappedDictionary = { known: "known" };
+			void dictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("binds mapped keys only in value and remapped-name branches", () => {
+		const scopedDiagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			interface Dictionary<Entry> {
+				[key: string]: Entry;
+			}
+			type MappedDictionary = { [Value in "known"]: Dictionary<Value> };
+			type RemappedDictionary = {
+				[Value in "known" as keyof Dictionary<Value>]: string;
+			};
+			const mappedDictionary: MappedDictionary = { known: {} };
+			const remappedDictionary: RemappedDictionary = { known: "known" };
+			void mappedDictionary;
+			void remappedDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+		const unscopedDiagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			interface Dictionary<Entry> {
+				[key: string]: Entry;
+			}
+			type MappedConstraint = { [Value in keyof Dictionary<Value>]: string };
+			const concreteDictionary: Dictionary<Value> = {};
+			void concreteDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(scopedDiagnostics).toEqual([]);
+		expect(diagnosticCount(unscopedDiagnostics, "no-unsafe-dictionary-type")).toBe(2);
+		expect(
+			unscopedDiagnostics.every((diagnostic) => diagnostic.message.includes("unknown")),
+		).toBe(true);
+	});
+
+	it("limits conditional infer parameters to the true branch", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Value = unknown;
+			interface Dictionary<Entry> {
+				[key: string]: Entry;
+			}
+			type Direct<T> = T extends infer Value ? Dictionary<Value> : never;
+			type Nested<T> = T extends Promise<infer Value>
+				? Dictionary<Value>
+				: Dictionary<Value>;
+			const concreteDictionary: Dictionary<Value> = {};
+			void concreteDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(2);
+		expect(diagnostics.every((diagnostic) => diagnostic.message.includes("unknown"))).toBe(true);
+	});
+
+	it("applies merged interface defaults to every declaration", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface Dictionary<Value> {
+				[key: string]: Value;
+			}
+			interface Dictionary<Value = unknown> {}
+			const defaultDictionary: Dictionary = {};
+			const explicitUnsafeDictionary: Dictionary<any> = {};
+			const explicitSafeDictionary: Dictionary<string> = {};
+			void defaultDictionary;
+			void explicitUnsafeDictionary;
+			void explicitSafeDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(2);
+		expect(diagnostics.filter((diagnostic) => diagnostic.message.includes("unknown"))).toHaveLength(
+			1,
+		);
+		expect(diagnostics.filter((diagnostic) => diagnostic.message.includes("any"))).toHaveLength(1);
+	});
+
+	it("resolves interface heritage through aliases and transparent wrappers", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type Base<Value> = { [key: string]: Value };
+			interface AliasDictionary<Value> extends Base<Value> {}
+			interface ReadonlyDictionary<Value> extends Readonly<Base<Value>> {}
+			const aliasUnsafe: AliasDictionary<unknown> = {};
+			const aliasSafe: AliasDictionary<string> = {};
+			const readonlyUnsafe: ReadonlyDictionary<any> = {};
+			const readonlySafe: ReadonlyDictionary<string> = {};
+			void aliasUnsafe;
+			void aliasSafe;
+			void readonlyUnsafe;
+			void readonlySafe;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(2);
+		expect(diagnostics.filter((diagnostic) => diagnostic.message.includes("unknown"))).toHaveLength(
+			1,
+		);
+		expect(diagnostics.filter((diagnostic) => diagnostic.message.includes("any"))).toHaveLength(1);
+	});
+
+	it("resolves wrapper-named type parameters before built-in wrappers", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface ReadonlyDictionary<Readonly> {
+				[key: string]: Readonly;
+			}
+			interface PartialDictionary<Partial> {
+				[key: string]: Partial;
+			}
+			interface RequiredDictionary<Required> {
+				[key: string]: Required;
+			}
+			interface NonNullableDictionary<NonNullable> {
+				[key: string]: NonNullable;
+			}
+			interface ValueDictionary<Value> {
+				[key: string]: Value;
+			}
+			const readonlyParameter: ReadonlyDictionary<unknown> = {};
+			const partialParameter: PartialDictionary<unknown> = {};
+			const requiredParameter: RequiredDictionary<unknown> = {};
+			const nonNullableParameter: NonNullableDictionary<unknown> = {};
+			const builtInUnsafe: ValueDictionary<Readonly<unknown>> = {};
+			const builtInSafe: ValueDictionary<Readonly<string>> = {};
+			void readonlyParameter;
+			void partialParameter;
+			void requiredParameter;
+			void nonNullableParameter;
+			void builtInUnsafe;
+			void builtInSafe;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(5);
+		expect(diagnostics.every((diagnostic) => diagnostic.message.includes("unknown"))).toBe(true);
+	});
+
+	it("terminates mixed alias and interface heritage cycles", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type AliasCycle<Value> = InterfaceCycle<Value>;
+			type Base<Value> = { [key: string]: Value };
+			interface InterfaceCycle<Value> extends AliasCycle<Value>, Base<Value> {}
+			const unsafeCycle: InterfaceCycle<unknown> = {};
+			const safeCycle: InterfaceCycle<string> = {};
+			void unsafeCycle;
+			void safeCycle;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(1);
+	});
+
+	it("reports one concrete interface definition once for two consumers", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface DirectUnsafeDictionary {
+				[key: string]: unknown;
+			}
+			const firstDirectConsumer: DirectUnsafeDictionary = {};
+			const secondDirectConsumer: DirectUnsafeDictionary = {};
+			void firstDirectConsumer;
+			void secondDirectConsumer;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(1);
+		expect(diagnostics[0]?.message).toContain("unknown");
+	});
+
+	it("keeps generic, defaulted, and inherited-substitution consumers reportable", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`interface GenericDictionary<Value> {
+				[key: string]: Value;
+			}
+			interface InheritedUnsafeDictionary extends GenericDictionary<unknown> {}
+			interface DefaultDictionary<Value> {
+				[key: string]: Value;
+			}
+			interface DefaultDictionary<Value = unknown> {}
+			const genericConsumer: GenericDictionary<unknown> = {};
+			const inheritedConsumer: InheritedUnsafeDictionary = {};
+			const defaultConsumer: DefaultDictionary = {};
+			void genericConsumer;
+			void inheritedConsumer;
+			void defaultConsumer;`,
+			["no-unsafe-dictionary-type"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(3);
+		expect(diagnostics.every((diagnostic) => diagnostic.message.includes("unknown"))).toBe(true);
+	});
+
+	it("keeps safe, non-dictionary, and cyclic interfaces opaque", () => {
+		const safeDiagnostics = lintAntiSlopFixture(
+			`interface SafeDictionary {
+				[key: string]: string;
+			}
+			const safeDictionary: SafeDictionary = {};
+			void safeDictionary;`,
+			["no-unsafe-dictionary-type"],
+		);
+		const opaqueDiagnostics = lintAntiSlopFixture(
+			`interface GenericObject<Value> {
+				value: Value;
+			}
+			interface SelfCycle<Value> extends SelfCycle<Value> {}
+			interface LeftCycle<Value> extends RightCycle<Value> {}
+			interface RightCycle<Value> extends LeftCycle<Value> {}
+			const objectValue: GenericObject<unknown> = { value: "known" };
+			const selfCycle: SelfCycle<unknown> = { known: "value" };
+			const mutualCycle = { known: "value" } as LeftCycle<unknown>;
+			void objectValue;
+			void selfCycle;
+			void mutualCycle;`,
+			["no-unsafe-dictionary-type", "no-known-value-widening"],
+		);
+
+		expect(safeDiagnostics).toEqual([]);
+		expect(opaqueDiagnostics).toEqual([]);
+	});
+
+	it("preserves alias, mapped, and empty-interface dictionary handling", () => {
+		const diagnostics = lintAntiSlopFixture(
+			`type AliasDictionary<Value> = { [key: string]: Value };
+			type MappedDictionary<Key extends string, Value> = { [Property in Key]: Value };
+			interface EmptyValue {}
+			type EmptyValueDictionary = { [key: string]: EmptyValue };
+			const aliasDictionary: AliasDictionary<unknown> = { known: "value" };
+			const mappedDictionary: MappedDictionary<string, unknown> = { known: "value" };
+			const emptyValueDictionary: EmptyValueDictionary = { known: {} };
+			void aliasDictionary;
+			void mappedDictionary;
+			void emptyValueDictionary;`,
+			["no-unsafe-dictionary-type", "no-known-value-widening"],
+		);
+
+		expect(diagnosticCount(diagnostics, "no-unsafe-dictionary-type")).toBe(3);
+		expect(diagnosticCount(diagnostics, "no-known-value-widening")).toBe(3);
+		expect(
+			diagnostics.filter((diagnostic) => diagnostic.message.includes("generic container")),
+		).toHaveLength(2);
+		expect(
+			diagnostics.filter((diagnostic) => diagnostic.message.includes("open dictionary")),
+		).toHaveLength(1);
+	});
+
+	it("preserves built-in and shadowed Record handling", () => {
+		const builtInDiagnostics = lintAntiSlopFixture(
+			`const dictionary: Record<string, unknown> = { known: "value" };
+			void dictionary;`,
+			["no-unsafe-dictionary-type", "no-known-value-widening"],
+		);
+		const shadowedDiagnostics = lintAntiSlopFixture(
+			`interface Record<Key, Value> {
+				key: Key;
+				value: Value;
+			}
+			const record: Record<string, unknown> = { key: "known", value: "known" };
+			void record;`,
+			["no-unsafe-dictionary-type", "no-known-value-widening"],
+		);
+
+		expect(diagnosticCount(builtInDiagnostics, "no-unsafe-dictionary-type")).toBe(1);
+		expect(diagnosticCount(builtInDiagnostics, "no-known-value-widening")).toBe(1);
+		expect(
+			builtInDiagnostics.some((diagnostic) => diagnostic.message.includes("open dictionary")),
+		).toBe(true);
+		expect(shadowedDiagnostics).toEqual([]);
+	});
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -12,12 +12,16 @@ const BUILT_INS = new Set([
 ]);
 const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
 
-type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
-
 type ResolvedType = {
 	readonly type: ESTree.TSType;
-	readonly substitutions: TypeAliasEnvironment;
+	readonly substitutions: TypeSubstitutionEnvironment;
 };
+
+const UNRESOLVED_TYPE_PARAMETER = Symbol("unresolved type parameter");
+
+type TypeSubstitution = ResolvedType | typeof UNRESOLVED_TYPE_PARAMETER;
+
+type TypeSubstitutionEnvironment = ReadonlyMap<string, TypeSubstitution>;
 
 export type UnsafeDictionary = {
 	readonly kind: "unsafe-dictionary";
@@ -103,17 +107,6 @@ function isBuiltIn(name: string, environment: TypeEnvironment): boolean {
 	return BUILT_INS.has(name) && !environment.shadowedBuiltIns.has(name);
 }
 
-function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
-	const unwrapped = unwrapTransparentType(type);
-	return (
-		unwrapped.type === "TSTypeReference" &&
-		typeReferenceName(unwrapped) === name &&
-		(unwrapped.typeArguments === null ||
-			unwrapped.typeArguments === undefined ||
-			unwrapped.typeArguments.params.length === 0)
-	);
-}
-
 function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
 	let current = type;
 	while (
@@ -155,42 +148,334 @@ function isEffectivelyEmptyInterface(
 	);
 }
 
-function resolvedSubstitutionArgument(
+function resolvedTypeArgument(
 	type: ESTree.TSType,
-	base: TypeAliasEnvironment,
-	resolving: ReadonlySet<string> = new Set(),
-): ESTree.TSType {
+	substitutions: TypeSubstitutionEnvironment,
+): TypeSubstitution {
 	const unwrapped = unwrapTransparentType(type);
-	if (unwrapped.type !== "TSTypeReference") return type;
-	const name = typeReferenceName(unwrapped);
-	if (name === null || resolving.has(name)) return type;
-	const substitution = base.get(name);
-	if (substitution === undefined) return type;
-	const nextResolving = new Set(resolving);
-	nextResolving.add(name);
-	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+	const name = unwrapped.type === "TSTypeReference" ? typeReferenceName(unwrapped) : null;
+	return (name === null ? undefined : substitutions.get(name)) ?? {
+		type,
+		substitutions: new Map(substitutions),
+	};
 }
 
-function aliasSubstitution(
-	alias: ESTree.TSTypeAliasDeclaration,
-	type: ESTree.TSTypeReference,
-	base: TypeAliasEnvironment,
-): TypeAliasEnvironment | null {
-	const parameters = alias.typeParameters?.params ?? [];
-	const arguments_ = type.typeArguments?.params ?? [];
-	const next = new Map(base);
+function typeParameterSubstitutions(
+	typeParameters: ESTree.TSTypeParameterDeclaration | null,
+	typeArguments: ESTree.TSTypeParameterInstantiation | null | undefined,
+	callerSubstitutions: TypeSubstitutionEnvironment,
+	defaultArguments: readonly (ESTree.TSType | undefined)[] = [],
+): TypeSubstitutionEnvironment | null {
+	const parameters = typeParameters?.params ?? [];
+	const arguments_ = typeArguments?.params ?? [];
+	const resolvedArguments = arguments_.map((argument) =>
+		resolvedTypeArgument(argument, callerSubstitutions),
+	);
+	const next: Map<string, TypeSubstitution> = new Map();
 	for (const [index, parameter] of parameters.entries()) {
-		const argument = arguments_[index] ?? parameter.default;
+		const argument = resolvedArguments[index];
+		if (argument === undefined) break;
+		next.set(parameter.name.name, argument);
+	}
+	for (const [index, parameter] of parameters.entries()) {
+		if (index < resolvedArguments.length) continue;
+		const argument = parameter.default ?? defaultArguments[index];
 		if (argument === null || argument === undefined) return null;
-		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+		next.set(parameter.name.name, resolvedTypeArgument(argument, next));
 	}
 	return next;
+}
+
+function genericScopeTypeParameters(
+	node: ESTree.Node,
+): ESTree.TSTypeParameterDeclaration | null {
+	switch (node.type) {
+		case "FunctionDeclaration":
+		case "FunctionExpression":
+		case "TSDeclareFunction":
+		case "TSEmptyBodyFunctionExpression":
+		case "ArrowFunctionExpression":
+		case "ClassDeclaration":
+		case "ClassExpression":
+		case "TSTypeAliasDeclaration":
+		case "TSInterfaceDeclaration":
+		case "TSCallSignatureDeclaration":
+		case "TSConstructSignatureDeclaration":
+		case "TSMethodSignature":
+		case "TSFunctionType":
+		case "TSConstructorType":
+			return node.typeParameters ?? null;
+		default:
+			return null;
+	}
+}
+
+function collectInferTypeParameterNamesFromTypeParameters(
+	typeParameters: ESTree.TSTypeParameterDeclaration | null,
+	names: Set<string>,
+): void {
+	for (const parameter of typeParameters?.params ?? []) {
+		if (parameter.constraint !== null) {
+			collectInferTypeParameterNames(parameter.constraint, names);
+		}
+		if (parameter.default !== null) collectInferTypeParameterNames(parameter.default, names);
+	}
+}
+
+function collectInferTypeParameterNamesFromTypeArguments(
+	typeArguments: ESTree.TSTypeParameterInstantiation | null,
+	names: Set<string>,
+): void {
+	for (const argument of typeArguments?.params ?? []) {
+		collectInferTypeParameterNames(argument, names);
+	}
+}
+
+function collectInferTypeParameterNamesFromTypeAnnotation(
+	typeAnnotation: ESTree.TSTypeAnnotation | null | undefined,
+	names: Set<string>,
+): void {
+	if (typeAnnotation !== null && typeAnnotation !== undefined) {
+		collectInferTypeParameterNames(typeAnnotation.typeAnnotation, names);
+	}
+}
+
+function collectInferTypeParameterNamesFromBindingPattern(
+	pattern: ESTree.BindingPattern,
+	names: Set<string>,
+): void {
+	switch (pattern.type) {
+		case "Identifier":
+			collectInferTypeParameterNamesFromTypeAnnotation(pattern.typeAnnotation, names);
+			return;
+		case "AssignmentPattern":
+			collectInferTypeParameterNamesFromBindingPattern(pattern.left, names);
+			return;
+		case "ObjectPattern":
+			collectInferTypeParameterNamesFromTypeAnnotation(pattern.typeAnnotation, names);
+			for (const property of pattern.properties) {
+				if (property.type === "Property") {
+					collectInferTypeParameterNamesFromBindingPattern(property.value, names);
+				} else {
+					collectInferTypeParameterNamesFromTypeAnnotation(property.typeAnnotation, names);
+					collectInferTypeParameterNamesFromBindingPattern(property.argument, names);
+				}
+			}
+			return;
+		case "ArrayPattern":
+			collectInferTypeParameterNamesFromTypeAnnotation(pattern.typeAnnotation, names);
+			for (const element of pattern.elements) {
+				if (element === null) continue;
+				if (element.type === "RestElement") {
+					collectInferTypeParameterNamesFromTypeAnnotation(element.typeAnnotation, names);
+					collectInferTypeParameterNamesFromBindingPattern(element.argument, names);
+				} else {
+					collectInferTypeParameterNamesFromBindingPattern(element, names);
+				}
+			}
+	}
+}
+
+function collectInferTypeParameterNamesFromParameters(
+	parameters: readonly ESTree.ParamPattern[],
+	names: Set<string>,
+): void {
+	for (const parameter of parameters) {
+		if (parameter.type === "TSParameterProperty") {
+			collectInferTypeParameterNamesFromBindingPattern(parameter.parameter, names);
+		} else if (parameter.type === "RestElement") {
+			collectInferTypeParameterNamesFromTypeAnnotation(parameter.typeAnnotation, names);
+			collectInferTypeParameterNamesFromBindingPattern(parameter.argument, names);
+		} else {
+			collectInferTypeParameterNamesFromBindingPattern(parameter, names);
+		}
+	}
+}
+
+function collectInferTypeParameterNamesFromSignature(
+	signature: ESTree.TSSignature,
+	names: Set<string>,
+): void {
+	switch (signature.type) {
+		case "TSPropertySignature":
+			collectInferTypeParameterNamesFromTypeAnnotation(signature.typeAnnotation, names);
+			return;
+		case "TSIndexSignature":
+			for (const parameter of signature.parameters) {
+				collectInferTypeParameterNamesFromTypeAnnotation(parameter.typeAnnotation, names);
+			}
+			collectInferTypeParameterNamesFromTypeAnnotation(signature.typeAnnotation, names);
+			return;
+		case "TSCallSignatureDeclaration":
+		case "TSConstructSignatureDeclaration":
+		case "TSMethodSignature":
+			collectInferTypeParameterNamesFromTypeParameters(signature.typeParameters, names);
+			collectInferTypeParameterNamesFromParameters(signature.params, names);
+			collectInferTypeParameterNamesFromTypeAnnotation(signature.returnType, names);
+	}
+}
+
+function collectInferTypeParameterNamesFromTupleElement(
+	element: ESTree.TSTupleElement,
+	names: Set<string>,
+): void {
+	if (element.type === "TSOptionalType" || element.type === "TSRestType") {
+		collectInferTypeParameterNames(element.typeAnnotation, names);
+	} else {
+		collectInferTypeParameterNames(element, names);
+	}
+}
+
+function collectInferTypeParameterNames(type: ESTree.TSType, names: Set<string>): void {
+	switch (type.type) {
+		case "TSArrayType":
+			collectInferTypeParameterNames(type.elementType, names);
+			return;
+		case "TSConditionalType":
+			collectInferTypeParameterNames(type.checkType, names);
+			collectInferTypeParameterNames(type.extendsType, names);
+			collectInferTypeParameterNames(type.trueType, names);
+			collectInferTypeParameterNames(type.falseType, names);
+			return;
+		case "TSConstructorType":
+		case "TSFunctionType":
+			collectInferTypeParameterNamesFromTypeParameters(type.typeParameters, names);
+			collectInferTypeParameterNamesFromParameters(type.params, names);
+			collectInferTypeParameterNamesFromTypeAnnotation(type.returnType, names);
+			return;
+		case "TSImportType":
+			collectInferTypeParameterNamesFromTypeArguments(type.typeArguments, names);
+			return;
+		case "TSIndexedAccessType":
+			collectInferTypeParameterNames(type.objectType, names);
+			collectInferTypeParameterNames(type.indexType, names);
+			return;
+		case "TSInferType":
+			names.add(type.typeParameter.name.name);
+			if (type.typeParameter.constraint !== null) {
+				collectInferTypeParameterNames(type.typeParameter.constraint, names);
+			}
+			if (type.typeParameter.default !== null) {
+				collectInferTypeParameterNames(type.typeParameter.default, names);
+			}
+			return;
+		case "TSIntersectionType":
+		case "TSUnionType":
+			for (const member of type.types) collectInferTypeParameterNames(member, names);
+			return;
+		case "TSMappedType":
+			collectInferTypeParameterNames(type.constraint, names);
+			if (type.nameType !== null) collectInferTypeParameterNames(type.nameType, names);
+			if (type.typeAnnotation !== null) collectInferTypeParameterNames(type.typeAnnotation, names);
+			return;
+		case "TSNamedTupleMember":
+			collectInferTypeParameterNamesFromTupleElement(type.elementType, names);
+			return;
+		case "TSParenthesizedType":
+		case "TSTypeOperator":
+		case "TSJSDocNonNullableType":
+		case "TSJSDocNullableType":
+			collectInferTypeParameterNames(type.typeAnnotation, names);
+			return;
+		case "TSTemplateLiteralType":
+			for (const embeddedType of type.types) {
+				collectInferTypeParameterNames(embeddedType, names);
+			}
+			return;
+		case "TSTupleType":
+			for (const element of type.elementTypes) {
+				collectInferTypeParameterNamesFromTupleElement(element, names);
+			}
+			return;
+		case "TSTypeLiteral":
+			for (const signature of type.members) {
+				collectInferTypeParameterNamesFromSignature(signature, names);
+			}
+			return;
+		case "TSTypePredicate":
+			collectInferTypeParameterNamesFromTypeAnnotation(type.typeAnnotation, names);
+			return;
+		case "TSTypeQuery":
+			if (type.exprName.type === "TSImportType") {
+				collectInferTypeParameterNames(type.exprName, names);
+			}
+			collectInferTypeParameterNamesFromTypeArguments(type.typeArguments, names);
+			return;
+		case "TSTypeReference":
+			collectInferTypeParameterNamesFromTypeArguments(type.typeArguments, names);
+			return;
+		case "TSAnyKeyword":
+		case "TSBigIntKeyword":
+		case "TSBooleanKeyword":
+		case "TSIntrinsicKeyword":
+		case "TSLiteralType":
+		case "TSNeverKeyword":
+		case "TSNullKeyword":
+		case "TSNumberKeyword":
+		case "TSObjectKeyword":
+		case "TSStringKeyword":
+		case "TSSymbolKeyword":
+		case "TSThisType":
+		case "TSUndefinedKeyword":
+		case "TSUnknownKeyword":
+		case "TSVoidKeyword":
+		case "TSJSDocUnknownType":
+			return;
+	}
+}
+
+function bindUnresolvedTypeParameter(
+	name: string,
+	substitutions: Map<string, TypeSubstitution>,
+): void {
+	if (!substitutions.has(name)) substitutions.set(name, UNRESOLVED_TYPE_PARAMETER);
+}
+
+function lexicalTypeParameterSubstitutions(type: ESTree.TSType): TypeSubstitutionEnvironment {
+	const substitutions = new Map<string, TypeSubstitution>();
+	let descendant: ESTree.Node = type;
+	let current: ESTree.Node | null = type.parent;
+	while (current !== null) {
+		for (const parameter of genericScopeTypeParameters(current)?.params ?? []) {
+			bindUnresolvedTypeParameter(parameter.name.name, substitutions);
+		}
+		if (
+			current.type === "TSMappedType" &&
+			(current.typeAnnotation === descendant || current.nameType === descendant)
+		) {
+			bindUnresolvedTypeParameter(current.key.name, substitutions);
+		}
+		if (current.type === "TSConditionalType" && current.trueType === descendant) {
+			const inferTypeParameterNames = new Set<string>();
+			collectInferTypeParameterNames(current.extendsType, inferTypeParameterNames);
+			for (const name of inferTypeParameterNames) {
+				bindUnresolvedTypeParameter(name, substitutions);
+			}
+		}
+		descendant = current;
+		current = current.parent;
+	}
+	return substitutions;
+}
+
+function mergedInterfaceTypeParameterDefaults(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): readonly (ESTree.TSType | undefined)[] {
+	const defaults: (ESTree.TSType | undefined)[] = [];
+	for (const declaration of declarations) {
+		for (const [index, parameter] of (declaration.typeParameters?.params ?? []).entries()) {
+			if (defaults[index] === undefined && parameter.default !== null) {
+				defaults[index] = parameter.default;
+			}
+		}
+	}
+	return defaults;
 }
 
 function unsafeDirectValue(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
-	substitutions: TypeAliasEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
 	resolvingAliases: ReadonlySet<string>,
 ): UnsafeDictionary["unsafeValue"] | null {
 	const unwrapped = unwrapTransparentType(type);
@@ -218,17 +503,21 @@ function unsafeDirectValue(
 	if (unwrapped.type !== "TSTypeReference") return null;
 	const name = typeReferenceName(unwrapped);
 	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		if (substitution === UNRESOLVED_TYPE_PARAMETER) return null;
+		return unsafeDirectValue(
+			substitution.type,
+			environment,
+			substitution.substitutions,
+			resolvingAliases,
+		);
+	}
 	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
 		const wrapped = unwrapped.typeArguments?.params[0];
 		return wrapped === undefined
 			? null
 			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
-	}
-	const substitution = substitutions.get(name);
-	if (substitution !== undefined) {
-		return isUnappliedReferenceTo(substitution, name)
-			? null
-			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
 	}
 	const interfaceDeclarations = environment.interfaces.get(name);
 	if (interfaceDeclarations !== undefined) {
@@ -236,7 +525,11 @@ function unsafeDirectValue(
 	}
 	const alias = environment.aliases.get(name);
 	if (alias === undefined || resolvingAliases.has(name)) return null;
-	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	const nextSubstitutions = typeParameterSubstitutions(
+		alias.typeParameters,
+		unwrapped.typeArguments,
+		substitutions,
+	);
 	if (nextSubstitutions === null) return null;
 	const nextResolving = new Set(resolvingAliases);
 	nextResolving.add(name);
@@ -246,8 +539,9 @@ function unsafeDirectValue(
 function dictionaryValueTypes(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
-	substitutions: TypeAliasEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
 	resolvingAliases: ReadonlySet<string>,
+	resolvingInterfaces: ReadonlySet<string>,
 ): readonly ResolvedType[] {
 	const unwrapped = unwrapTransparentType(type);
 
@@ -260,55 +554,161 @@ function dictionaryValueTypes(
 	}
 
 	if (unwrapped.type === "TSMappedType") {
+		const valueSubstitutions = new Map(substitutions);
+		valueSubstitutions.set(unwrapped.key.name, UNRESOLVED_TYPE_PARAMETER);
 		return unwrapped.typeAnnotation === null
 			? []
-			: [{ type: unwrapped.typeAnnotation, substitutions }];
+			: [{ type: unwrapped.typeAnnotation, substitutions: valueSubstitutions }];
 	}
 
 	if (unwrapped.type !== "TSTypeReference") return [];
 	const name = typeReferenceName(unwrapped);
 	if (name === null) return [];
+	return namedDictionaryValueTypes(
+		name,
+		unwrapped.typeArguments,
+		environment,
+		substitutions,
+		resolvingAliases,
+		resolvingInterfaces,
+	);
+}
 
+function namedDictionaryValueTypes(
+	name: string,
+	typeArguments: ESTree.TSTypeParameterInstantiation | null | undefined,
+	environment: TypeEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+	resolvingInterfaces: ReadonlySet<string>,
+): readonly ResolvedType[] {
 	const substitution = substitutions.get(name);
 	if (substitution !== undefined) {
-		return isUnappliedReferenceTo(substitution, name)
-			? []
-			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+		if (substitution === UNRESOLVED_TYPE_PARAMETER) return [];
+		return dictionaryValueTypes(
+			substitution.type,
+			environment,
+			substitution.substitutions,
+			resolvingAliases,
+			resolvingInterfaces,
+		);
 	}
 
 	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
-		const wrapped = unwrapped.typeArguments?.params[0];
+		const wrapped = typeArguments?.params[0];
 		return wrapped === undefined
 			? []
-			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+			: dictionaryValueTypes(
+					wrapped,
+					environment,
+					substitutions,
+					resolvingAliases,
+					resolvingInterfaces,
+				);
 	}
 
 	if (name === "Record" && isBuiltIn(name, environment)) {
-		const value = unwrapped.typeArguments?.params[1] ?? null;
+		const value = typeArguments?.params[1] ?? null;
 		return value === null ? [] : [{ type: value, substitutions }];
 	}
 
 	if ((name === "Pick" || name === "Omit") && isBuiltIn(name, environment)) {
-		const source = unwrapped.typeArguments?.params[0];
+		const source = typeArguments?.params[0];
 		return source === undefined
 			? []
-			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+			: dictionaryValueTypes(
+					source,
+					environment,
+					substitutions,
+					resolvingAliases,
+					resolvingInterfaces,
+				);
+	}
+
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return interfaceDictionaryValueTypes(
+			name,
+			interfaceDeclarations,
+			typeArguments,
+			environment,
+			substitutions,
+			resolvingAliases,
+			resolvingInterfaces,
+		);
 	}
 
 	const alias = environment.aliases.get(name);
 	if (alias === undefined || resolvingAliases.has(name)) return [];
-	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	const nextSubstitutions = typeParameterSubstitutions(
+		alias.typeParameters,
+		typeArguments,
+		substitutions,
+	);
 	if (nextSubstitutions === null) return [];
 	const nextResolving = new Set(resolvingAliases);
 	nextResolving.add(name);
-	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+	return dictionaryValueTypes(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+		resolvingInterfaces,
+	);
+}
+
+function interfaceDictionaryValueTypes(
+	name: string,
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+	typeArguments: ESTree.TSTypeParameterInstantiation | null | undefined,
+	environment: TypeEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+	resolvingInterfaces: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	if (resolvingInterfaces.has(name)) return [];
+	const nextResolvingInterfaces = new Set(resolvingInterfaces);
+	nextResolvingInterfaces.add(name);
+	const defaultArguments = mergedInterfaceTypeParameterDefaults(declarations);
+
+	return declarations.flatMap((declaration): readonly ResolvedType[] => {
+		const nextSubstitutions = typeParameterSubstitutions(
+			declaration.typeParameters,
+			typeArguments,
+			substitutions,
+			defaultArguments,
+		);
+		if (nextSubstitutions === null) return [];
+		const directValueTypes = declaration.body.body.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature"
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions: nextSubstitutions }]
+				: [],
+		);
+		const inheritedValueTypes = declaration.extends.flatMap((heritage): readonly ResolvedType[] => {
+			if (heritage.expression.type !== "Identifier") return [];
+			return namedDictionaryValueTypes(
+				heritage.expression.name,
+				heritage.typeArguments,
+				environment,
+				nextSubstitutions,
+				resolvingAliases,
+				nextResolvingInterfaces,
+			);
+		});
+		return [...directValueTypes, ...inheritedValueTypes];
+	});
 }
 
 export function classifyUnsafeDictionaryValue(
 	valueType: ESTree.TSType,
 	environment: TypeEnvironment,
 ): UnsafeDictionary | null {
-	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	const unsafeValue = unsafeDirectValue(
+		valueType,
+		environment,
+		lexicalTypeParameterSubstitutions(valueType),
+		new Set(),
+	);
 	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
 }
 
@@ -316,7 +716,13 @@ export function classifyUnsafeDictionary(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
 ): UnsafeDictionary | null {
-	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+	for (const valueType of dictionaryValueTypes(
+		type,
+		environment,
+		lexicalTypeParameterSubstitutions(type),
+		new Set(),
+		new Set(),
+	)) {
 		const unsafeValue = unsafeDirectValue(
 			valueType.type,
 			environment,
@@ -331,15 +737,31 @@ export function classifyUnsafeDictionary(
 function resolvesToDictionary(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
-	substitutions: TypeAliasEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
 	resolvingAliases: ReadonlySet<string>,
+	resolvingInterfaces: ReadonlySet<string>,
 ): boolean {
-	return dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0;
+	return (
+		dictionaryValueTypes(type, environment, substitutions, resolvingAliases, resolvingInterfaces)
+			.length > 0
+	);
 }
 
 export function classifyWideningTarget(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
+): WideningTarget | null {
+	return classifyWideningTargetInScope(
+		type,
+		environment,
+		lexicalTypeParameterSubstitutions(type),
+	);
+}
+
+function classifyWideningTargetInScope(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
 ): WideningTarget | null {
 	const unwrapped = unwrapTransparentType(type);
 	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
@@ -355,35 +777,66 @@ export function classifyWideningTarget(
 	if (unwrapped.type !== "TSTypeReference") return null;
 	const name = typeReferenceName(unwrapped);
 	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return substitution === UNRESOLVED_TYPE_PARAMETER
+			? null
+			: classifyWideningTargetInScope(
+					substitution.type,
+					environment,
+					substitution.substitutions,
+				);
+	}
 	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
 		const wrapped = unwrapped.typeArguments?.params[0];
-		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+		return wrapped === undefined
+			? null
+			: classifyWideningTargetInScope(wrapped, environment, substitutions);
 	}
 	if (name === "Record" && isBuiltIn(name, environment)) return { kind: "open dictionary" };
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return resolvesToDictionary(unwrapped, environment, substitutions, new Set(), new Set())
+			? {
+					kind: interfaceDeclarations.some(
+						(declaration) => (declaration.typeParameters?.params.length ?? 0) > 0,
+					)
+						? "generic container"
+						: "open dictionary",
+				}
+			: null;
+	}
 	const alias = environment.aliases.get(name);
 	if (alias === undefined) return null;
+	const calleeSubstitutions = typeParameterSubstitutions(
+		alias.typeParameters,
+		unwrapped.typeArguments,
+		substitutions,
+	);
+	if (calleeSubstitutions === null) return null;
 	if ((alias.typeParameters?.params.length ?? 0) > 0) {
-		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
-		return substitutions !== null &&
-			resolvesToDictionary(alias.typeAnnotation, environment, substitutions, new Set([name]))
+		return resolvesToDictionary(
+			alias.typeAnnotation,
+			environment,
+			calleeSubstitutions,
+			new Set([name]),
+			new Set(),
+		)
 			? { kind: "generic container" }
 			: null;
 	}
-	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
-	if (substitutions === null) return null;
-	const resolved = classifyAliasBroadTarget(
+	return classifyAliasBroadTarget(
 		alias.typeAnnotation,
 		environment,
-		substitutions,
+		calleeSubstitutions,
 		new Set([name]),
 	);
-	return resolved;
 }
 
 function isBroadMappedKey(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
-	substitutions: TypeAliasEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
 ): boolean {
 	const unwrapped = unwrapTransparentType(type);
 	if (
@@ -402,8 +855,9 @@ function isBroadMappedKey(
 	const name = typeReferenceName(unwrapped);
 	if (name === null) return false;
 	const substitution = substitutions.get(name);
-	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
-		return isBroadMappedKey(substitution, environment, substitutions);
+	if (substitution !== undefined) {
+		if (substitution === UNRESOLVED_TYPE_PARAMETER) return false;
+		return isBroadMappedKey(substitution.type, environment, substitution.substitutions);
 	}
 	return name === "PropertyKey" && isBuiltIn(name, environment);
 }
@@ -411,7 +865,7 @@ function isBroadMappedKey(
 function classifyAliasBroadTarget(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
-	substitutions: TypeAliasEnvironment,
+	substitutions: TypeSubstitutionEnvironment,
 	resolvingAliases: ReadonlySet<string>,
 ): WideningTarget | null {
 	const unwrapped = unwrapTransparentType(type);
@@ -432,14 +886,13 @@ function classifyAliasBroadTarget(
 	if (name === null) return null;
 	const substitution = substitutions.get(name);
 	if (substitution !== undefined) {
-		return isUnappliedReferenceTo(substitution, name)
-			? null
-			: classifyAliasBroadTarget(
-					substitution,
-					environment,
-					substitutions,
-					resolvingAliases,
-				);
+		if (substitution === UNRESOLVED_TYPE_PARAMETER) return null;
+		return classifyAliasBroadTarget(
+			substitution.type,
+			environment,
+			substitution.substitutions,
+			resolvingAliases,
+		);
 	}
 	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
 		const wrapped = unwrapped.typeArguments?.params[0];
@@ -450,9 +903,18 @@ function classifyAliasBroadTarget(
 	if (name === "Record" && isBuiltIn(name, environment)) {
 		return { kind: "open dictionary" };
 	}
+	if (environment.interfaces.has(name)) {
+		return resolvesToDictionary(unwrapped, environment, substitutions, resolvingAliases, new Set())
+			? { kind: "open dictionary" }
+			: null;
+	}
 	const alias = environment.aliases.get(name);
 	if (alias === undefined || resolvingAliases.has(name)) return null;
-	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	const nextSubstitutions = typeParameterSubstitutions(
+		alias.typeParameters,
+		unwrapped.typeArguments,
+		substitutions,
+	);
 	if (nextSubstitutions === null) return null;
 	const nextResolving = new Set(resolvingAliases);
 	nextResolving.add(name);


### PR DESCRIPTION
## Summary
- resolve generic interface index signatures with declaration merging, defaults, heritage, and cycle guards
- preserve caller and declaration lexical type scopes across aliases, wrappers, mapped keys, and conditional inference
- avoid duplicate concrete interface diagnostics while retaining generic use-site checks
- add end-to-end Oxlint rule fixtures to the aggregate npm test gate

## Verification
- 26 focused anti-slop integration tests
- 356 aggregate npm tests
- desktop typecheck and strict changed-tool TypeScript check
- scoped Oxlint with zero findings
- changed-path format check and git diff check
- final independent review: no findings

Full repository lint and format retain pre-existing findings in unchanged files.

Closes #6