### PR TITLE
design: app window chrome, page spacing, and marketing palette

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,41 +100,27 @@ npm run check
 
 ## Project Structure
 
+Top-level workspaces only. Update this tree when a workspace is added or
+removed; do not list individual source files here.
+
 ```
 /
 ├── apps/
-│   └── desktop/                  # The Tauri app (npm package "skill-studio")
-│       ├── src/                  # React frontend
-│       │   ├── components/
-│       │   │   ├── SkillStore/   # SkillStore, SkillBrowser, SkillDetailPanel,
-│       │   │   │                 # SkillDetailHeader, SkillContent, InstallControls,
-│       │   │   │                 # AgentTargetSelector, SkillSearchBar, InstallProgressModal
-│       │   │   └── ui/           # Toast, ToastContainer
-│       │   ├── lib/
-│       │   │   ├── skill-types.ts        # Type definitions
-│       │   │   └── skill-api.ts          # Tauri IPC wrappers
-│       │   ├── store/
-│       │   │   └── appStore.ts   # Zustand store
-│       │   ├── App.tsx           # Main app component
-│       │   └── main.tsx          # Entry point
-│       └── src-tauri/            # Rust backend
-│           ├── src/
-│           │   ├── skills/
-│           │   │   ├── mod.rs
-│           │   │   ├── agents.rs         # AgentId, agent paths
-│           │   │   ├── api.rs            # skills.sh HTTP client
-│           │   │   ├── commands.rs       # Tauri IPC commands
-│           │   │   ├── frontmatter.rs    # SKILL.md frontmatter parsing/validation
-│           │   │   ├── lock_file.rs      # ~/.agents/.skill-lock.json
-│           │   │   ├── plugins.rs        # Native plugin cache enumeration
-│           │   │   ├── provenance.rs     # Source-kind classification
-│           │   │   ├── scan.rs           # Installed-skill directory scanner
-│           │   │   └── skill_dto.rs      # Serde DTOs sent to the frontend
-│           │   ├── lib.rs                # Library entry
-│           │   └── main.rs               # Rust entry point
-│           └── Cargo.toml                # Rust dependencies
+│   ├── cli/                      # Rust CLI, thin adapter over skill-studio-core
+│   ├── desktop/                  # Tauri app (npm package "skill-studio")
+│   │   ├── src/                  # React frontend: components/, hooks/, lib/, store/
+│   │   └── src-tauri/src/skills/ # Rust backend: scan, lifecycle, Tauri commands
+│   ├── mcp/                      # Rust MCP server over skill-studio-core, stdio
+│   ├── server/                   # Node proxy for the skills.sh API (port 8787)
+│   └── tui/                      # Terminal UI (Node)
+├── crates/
+│   ├── skill-studio-core/        # Scope-confined core: scan, ops, events, DTOs, schema/
+│   └── skill-studio-host/        # Real-world port adapters for the core crate
 ├── packages/
-│   └── ui/                       # Shared UI package placeholder (@skill-studio/ui)
+│   ├── lib/                      # Shared TypeScript library
+│   ├── marketing/                # Marketing site (Vite + StyleX) and Remotion walkthroughs
+│   └── ui/                       # Shared UI primitives (@skill-studio/ui)
+├── docs/                         # Specs and reference docs
 ├── tools/
 │   └── oxlint/anti-slop/         # Local oxlint JS plugin
 └── package.json                  # npm workspaces root
@@ -143,6 +129,12 @@ npm run check
 ## Code Style Guidelines
 
 ### TypeScript/React
+
+**UI primitives:** Form controls and buttons come from `@skill-studio/ui`
+(`Input`, `Textarea`, `Select`, `Button`, and the other exports in
+`packages/ui/src/index.ts`). Raw `<input>`, `<textarea>`, `<select>`, and
+`<button>` are allowed only inside `packages/ui`; the
+`anti-slop/no-raw-form-elements` lint rule enforces this.
 
 **Imports:** Group in order - React, external libs, internal modules, types
 
@@ -286,20 +278,20 @@ let home = get_home_dir().ok_or("Could not find home directory")?;
 
 ### Key Files
 
-| Purpose               | File                                              |
-| --------------------- | ------------------------------------------------- |
-| Main App              | `apps/desktop/src/App.tsx`                        |
-| State Store           | `apps/desktop/src/store/appStore.ts`              |
-| Skill types           | `apps/desktop/src/lib/skill-types.ts`             |
-| Tauri IPC wrappers    | `apps/desktop/src/lib/skill-api.ts`               |
-| Tauri commands        | `apps/desktop/src-tauri/src/skills/commands.rs`   |
-| Scanner               | `apps/desktop/src-tauri/src/skills/scan.rs`       |
-| Provenance            | `apps/desktop/src-tauri/src/skills/provenance.rs` |
-| Agent paths           | `apps/desktop/src-tauri/src/skills/agents.rs`     |
-| Lint config           | `.oxlintrc.json`                                  |
-| Format config         | `.oxfmtrc.json`                                   |
-| Tauri Config          | `apps/desktop/src-tauri/tauri.conf.json`          |
-| TS Config             | `apps/desktop/tsconfig.json`                      |
+| Purpose            | File                                              |
+| ------------------ | ------------------------------------------------- |
+| Main App           | `apps/desktop/src/App.tsx`                        |
+| State Store        | `apps/desktop/src/store/appStore.ts`              |
+| Skill types        | `apps/desktop/src/lib/skill-types.ts`             |
+| Tauri IPC wrappers | `apps/desktop/src/lib/skill-api.ts`               |
+| Tauri commands     | `apps/desktop/src-tauri/src/skills/commands.rs`   |
+| Scanner            | `apps/desktop/src-tauri/src/skills/scan.rs`       |
+| Provenance         | `apps/desktop/src-tauri/src/skills/provenance.rs` |
+| Agent paths        | `apps/desktop/src-tauri/src/skills/agents.rs`     |
+| Lint config        | `.oxlintrc.json`                                  |
+| Format config      | `.oxfmtrc.json`                                   |
+| Tauri Config       | `apps/desktop/src-tauri/tauri.conf.json`          |
+| TS Config          | `apps/desktop/tsconfig.json`                      |
 
 ### TypeScript Strictness
 

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,11 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "dialog:default", "dialog:allow-open", "dialog:allow-save"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging",
+    "dialog:default",
+    "dialog:allow-open",
+    "dialog:allow-save"
+  ]
 }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Skill Studio",
+  "mainBinaryName": "skill-studio-desktop",
   "version": "0.1.0",
   "identifier": "com.skillstudio.app",
   "build": {
@@ -19,6 +20,8 @@
         "minHeight": 600,
         "center": true,
         "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": false,
         "resizable": true
       }
     ],

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -140,7 +140,10 @@ function App() {
           emittedSnapshotRevision={emittedSnapshotRevision}
           requestRescan={requestRescan}
         />
-        <main className="flex-1 overflow-y-auto">{main}</main>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div data-tauri-drag-region className="h-9 shrink-0" />
+          <main className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">{main}</main>
+        </div>
 
         <AddSkillSheet />
         <Toaster

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -140,8 +140,9 @@ function App() {
           emittedSnapshotRevision={emittedSnapshotRevision}
           requestRescan={requestRescan}
         />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <div data-tauri-drag-region className="h-9 shrink-0" />
+        <div className="relative flex min-w-0 flex-1 flex-col">
+          {/* Overlay title-bar band: the window stays draggable from the top edge without pushing page content down. Matches the 28px macOS title-bar height. */}
+          <div data-tauri-drag-region className="absolute inset-x-0 top-0 z-10 h-7" />
           <main className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">{main}</main>
         </div>
 

--- a/apps/desktop/src/components/Home/HomeView.tsx
+++ b/apps/desktop/src/components/Home/HomeView.tsx
@@ -9,7 +9,7 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
 import { ChevronDown } from "lucide-react";
-import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "@skill-studio/ui";
+import { Button, Collapsible, CollapsiblePanel, CollapsibleTrigger } from "@skill-studio/ui";
 import {
   attentionGroups,
   homeInvocationCounts,
@@ -48,12 +48,11 @@ const RECENTLY_USED_COUNT = 5;
 const MAX_ROWS_PER_GROUP = 6;
 
 /** Text link style shared by every "Show all"/"Show everything"/"Learn more" affordance on Home. */
-const LINK_CLASS =
-  "inline-flex items-center gap-1 border-0 bg-none p-0 text-small text-accent hover:underline";
+const LINK_CLASS = "h-auto gap-1 p-0 text-small";
 
 /** One inbox row's trailing action - a text button or, on the "Recently used" rows, a plain count. */
 const ROW_ACTION_CLASS =
-  "h-9 min-w-10 border-0 bg-none p-0 text-right text-small text-text-tertiary hover:text-accent";
+  "h-9 min-w-10 justify-end p-0 text-right text-small text-text-tertiary hover:bg-transparent hover:text-accent";
 
 /** The one filter that can be active at a time: a stat tile or the idle bar segment. */
 type HomeFilter = "broken" | "warn" | "upd" | "unused";
@@ -116,13 +115,14 @@ function InboxRow({
         className={`size-1.5 shrink-0 rounded-full ${severity === "error" ? "bg-error" : severity === "warning" ? "bg-warning" : ""}`}
       />
       <span className="flex min-w-0 items-center gap-2">
-        <button
-          className="min-w-0 truncate border-0 bg-none p-0 text-left text-body text-text-primary hover:text-accent"
+        <Button
+          variant="ghost"
+          className="h-auto min-w-0 truncate p-0 text-left text-body text-text-primary hover:bg-transparent hover:text-accent"
           onClick={onOpen}
           title={skill.name}
         >
           {skill.name}
-        </button>
+        </Button>
         <HarnessBadges skill={skill} />
       </span>
       <span className="truncate text-small text-text-tertiary">{detail}</span>
@@ -156,9 +156,9 @@ function ShowAllLink({
 }) {
   return (
     <div className="flex h-9 items-center px-4">
-      <button className={LINK_CLASS} onClick={onClick}>
+      <Button variant="link" className={LINK_CLASS} onClick={onClick}>
         {label} {count}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -197,13 +197,13 @@ function PullLatestButton({ skill }: { skill: InstalledSkill }) {
   };
 
   return (
-    <button className={ROW_ACTION_CLASS} onClick={handlePull} disabled={isPulling}>
+    <Button variant="ghost" className={ROW_ACTION_CLASS} onClick={handlePull} disabled={isPulling}>
       {isPulling ? (
         <span className="inline-block size-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
       ) : (
         "Pull latest"
       )}
-    </button>
+    </Button>
   );
 }
 
@@ -229,13 +229,13 @@ function ParkButton({ skill }: { skill: InstalledSkill }) {
   };
 
   return (
-    <button className={ROW_ACTION_CLASS} onClick={handlePark} disabled={isParking}>
+    <Button variant="ghost" className={ROW_ACTION_CLASS} onClick={handlePark} disabled={isParking}>
       {isParking ? (
         <span className="inline-block size-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
       ) : (
         "Park"
       )}
-    </button>
+    </Button>
   );
 }
 
@@ -269,27 +269,28 @@ function WarningRowAction({
 }) {
   if (issue.kind === "duplicate") {
     return (
-      <button className={ROW_ACTION_CLASS} onClick={onCompare}>
+      <Button variant="ghost" className={ROW_ACTION_CLASS} onClick={onCompare}>
         Compare
-      </button>
+      </Button>
     );
   }
   if (issue.kind === "linked-root" && issue.harness && issue.root) {
     const { harness, root } = issue;
     const harnessLabel = issue.harnessLabel ?? harness;
     return (
-      <button
+      <Button
+        variant="ghost"
         className={ROW_ACTION_CLASS}
         onClick={() => onConvertLinkedRoot(harness, harnessLabel, root)}
       >
         {issueActionLabel(issue.kind)}
-      </button>
+      </Button>
     );
   }
   return (
-    <button className={ROW_ACTION_CLASS} onClick={onOpen}>
+    <Button variant="ghost" className={ROW_ACTION_CLASS} onClick={onOpen}>
       {issueActionLabel(issue.kind)}
-    </button>
+    </Button>
   );
 }
 
@@ -362,8 +363,9 @@ function HomeStatTiles({
   return (
     <div className="grid grid-cols-3 gap-3">
       <div className="group/stat relative flex">
-        <button
-          className={`flex flex-1 flex-col gap-1 rounded-md border border-border-subtle bg-bg-elevated px-4 py-3.5 text-left transition-[border-color,background-color,transform] duration-150 hover:border-border hover:bg-bg-hover active:scale-98 aria-pressed:border-accent aria-pressed:bg-accent-softer aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)] ${
+        <Button
+          variant="outline"
+          className={`h-auto flex-1 flex-col items-stretch gap-1 rounded-md border-border-subtle bg-bg-elevated px-4 py-3.5 justify-start text-left active:scale-98 aria-pressed:border-accent aria-pressed:bg-accent-softer ${
             broken.length > 0 ? "[&_.home-stat-value]:text-error" : ""
           }`}
           aria-pressed={filter === "broken"}
@@ -377,7 +379,7 @@ function HomeStatTiles({
           <span className="home-stat-value text-display leading-[1.1] font-semibold tracking-[-0.02em] tabular-nums">
             {broken.length}
           </span>
-        </button>
+        </Button>
         <span className="absolute top-3.5 right-3.5 opacity-0 group-hover/stat:opacity-100 group-focus-within/stat:opacity-100 has-[[aria-expanded=true]]:opacity-100">
           <InfoPopover label="About broken" title="Broken and warnings" onLearnMore={onLearnMore}>
             An agent loads nothing, or something you did not intend: a dead link, a SKILL.md the
@@ -387,8 +389,9 @@ function HomeStatTiles({
       </div>
 
       <div className="group/stat relative flex">
-        <button
-          className={`flex flex-1 flex-col gap-1 rounded-md border border-border-subtle bg-bg-elevated px-4 py-3.5 text-left transition-[border-color,background-color,transform] duration-150 hover:border-border hover:bg-bg-hover active:scale-98 aria-pressed:border-accent aria-pressed:bg-accent-softer aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)] ${
+        <Button
+          variant="outline"
+          className={`h-auto flex-1 flex-col items-stretch gap-1 rounded-md border-border-subtle bg-bg-elevated px-4 py-3.5 justify-start text-left active:scale-98 aria-pressed:border-accent aria-pressed:bg-accent-softer ${
             warnings.length > 0 ? "[&_.home-stat-value]:text-warning" : ""
           }`}
           aria-pressed={filter === "warn"}
@@ -402,7 +405,7 @@ function HomeStatTiles({
           <span className="home-stat-value text-display leading-[1.1] font-semibold tracking-[-0.02em] tabular-nums">
             {warnings.length}
           </span>
-        </button>
+        </Button>
         <span className="absolute top-3.5 right-3.5 opacity-0 group-hover/stat:opacity-100 group-focus-within/stat:opacity-100 has-[[aria-expanded=true]]:opacity-100">
           <InfoPopover label="About warnings" title="Broken and warnings" onLearnMore={onLearnMore}>
             Everything still loads, but the state drifted: copies that differ between harnesses,
@@ -412,8 +415,9 @@ function HomeStatTiles({
       </div>
 
       <div className="flex">
-        <button
-          className="flex flex-1 flex-col gap-1 rounded-md border border-border-subtle bg-bg-elevated px-4 py-3.5 text-left transition-[border-color,background-color,transform] duration-150 hover:border-border hover:bg-bg-hover active:scale-98 aria-pressed:border-accent aria-pressed:bg-accent-softer aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)]"
+        <Button
+          variant="outline"
+          className="h-auto flex-1 flex-col items-stretch gap-1 rounded-md border-border-subtle bg-bg-elevated px-4 py-3.5 justify-start text-left active:scale-98 aria-pressed:border-accent aria-pressed:bg-accent-softer"
           aria-pressed={filter === "upd"}
           onClick={() => toggleFilter("upd")}
         >
@@ -425,7 +429,7 @@ function HomeStatTiles({
           <span className="text-display leading-[1.1] font-semibold tracking-[-0.02em] tabular-nums">
             {updates.length}
           </span>
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -471,35 +475,40 @@ function InvocationCostCard({
         <div className="flex h-7 gap-0.5" role="group" aria-label="Who can invoke">
           {inv.both > 0 && (
             <TooltipControl content="Open in Skills">
-              <button
-                className="inline-flex items-center gap-1 overflow-hidden rounded-xs bg-accent-soft px-2.5 text-small whitespace-nowrap text-text-primary transition-[filter] hover:brightness-115 aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)]"
+              <Button
+                size="sm"
+                className="gap-1 overflow-hidden rounded-xs bg-accent-soft px-2.5 text-small whitespace-nowrap text-text-primary hover:brightness-115 aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)]"
                 style={{ flex: `${inv.both} 0 auto` }}
                 onClick={() => goToInvocation("both")}
               >
                 <span className="tabular-nums">{inv.both}</span> you or the model
-              </button>
+              </Button>
             </TooltipControl>
           )}
           {inv.modelOnly > 0 && (
             <TooltipControl content="Open in Skills">
-              <button
-                className="inline-flex items-center gap-1 overflow-hidden rounded-xs bg-accent-softer px-2.5 text-small whitespace-nowrap text-text-secondary transition-[filter] hover:brightness-115 aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)] aria-pressed:text-text-primary"
+              <Button
+                variant="secondary"
+                size="sm"
+                className="gap-1 overflow-hidden rounded-xs bg-accent-softer px-2.5 text-small whitespace-nowrap text-text-secondary hover:brightness-115 aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)] aria-pressed:text-text-primary"
                 style={{ flex: `${inv.modelOnly} 0 auto` }}
                 onClick={() => goToInvocation("model-only")}
               >
                 <span className="tabular-nums">{inv.modelOnly}</span> model only
-              </button>
+              </Button>
             </TooltipControl>
           )}
           {inv.userOnly > 0 && (
             <TooltipControl content="Open in Skills">
-              <button
-                className="inline-flex items-center gap-1 overflow-hidden rounded-xs bg-bg-tertiary px-2.5 text-small whitespace-nowrap text-text-secondary transition-[filter] hover:brightness-115 aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)] aria-pressed:text-text-primary"
+              <Button
+                variant="secondary"
+                size="sm"
+                className="gap-1 overflow-hidden rounded-xs bg-bg-tertiary px-2.5 text-small whitespace-nowrap text-text-secondary hover:brightness-115 aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)] aria-pressed:text-text-primary"
                 style={{ flex: `${inv.userOnly} 0 auto` }}
                 onClick={() => goToInvocation("user-only")}
               >
                 <span className="tabular-nums">{inv.userOnly}</span> you only
-              </button>
+              </Button>
             </TooltipControl>
           )}
         </div>
@@ -532,25 +541,28 @@ function InvocationCostCard({
           ) : (
             <>
               <TooltipControl content="Open in Skills">
-                <button
-                  className="inline-flex items-center gap-1 overflow-hidden rounded-xs bg-accent-soft px-2.5 text-small whitespace-nowrap text-text-primary transition-[filter] hover:brightness-115"
+                <Button
+                  size="sm"
+                  className="gap-1 overflow-hidden rounded-xs bg-accent-soft px-2.5 text-small whitespace-nowrap text-text-primary hover:brightness-115"
                   style={{ flex: `${cost.usedTokens} 0 auto` }}
                   onClick={() => goToSkills({ usage: "used-30d" })}
                 >
                   <span className="tabular-nums">{formatTokens(cost.usedTokens)}</span> ·{" "}
                   <span className="tabular-nums">{cost.usedCount}</span> skills used in 30 days
-                </button>
+                </Button>
               </TooltipControl>
               <TooltipControl content="Show the skills not used in 30 days">
-                <button
-                  className="inline-flex items-center gap-1 overflow-hidden rounded-xs bg-bg-tertiary px-2.5 text-small whitespace-nowrap text-text-secondary transition-[filter] hover:brightness-115 aria-pressed:text-text-primary aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)]"
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="gap-1 overflow-hidden rounded-xs bg-bg-tertiary px-2.5 text-small whitespace-nowrap text-text-secondary hover:brightness-115 aria-pressed:text-text-primary aria-pressed:shadow-[inset_0_0_0_1px_var(--color-accent)]"
                   style={{ flex: `${cost.idleTokens} 0 auto` }}
                   aria-pressed={filter === "unused"}
                   onClick={() => toggleFilter("unused")}
                 >
                   <span className="tabular-nums">{formatTokens(cost.idleTokens)}</span> ·{" "}
                   <span className="tabular-nums">{cost.idleCount}</span> skills not used in 30 days
-                </button>
+                </Button>
               </TooltipControl>
             </>
           )}
@@ -646,9 +658,9 @@ export function HomeView({ snapshot, isLoading, onSelectSkill }: HomeViewProps) 
         {filter && (
           <div className="flex h-9 items-center gap-2.5 px-3 text-small text-text-tertiary">
             Showing one group ·{" "}
-            <button className={LINK_CLASS} onClick={() => setFilter(null)}>
+            <Button variant="link" className={LINK_CLASS} onClick={() => setFilter(null)}>
               Show everything
-            </button>
+            </Button>
           </div>
         )}
 
@@ -675,12 +687,13 @@ export function HomeView({ snapshot, isLoading, onSelectSkill }: HomeViewProps) 
                     onOpen={() => onSelectSkill(issue.skill.name)}
                     detail={<span title={issue.detail}>{issue.detail}</span>}
                     action={
-                      <button
+                      <Button
+                        variant="ghost"
                         className={ROW_ACTION_CLASS}
                         onClick={() => onSelectSkill(issue.skill.name)}
                       >
                         {issueActionLabel(issue.kind)}
-                      </button>
+                      </Button>
                     }
                   />
                 ))}
@@ -789,12 +802,13 @@ export function HomeView({ snapshot, isLoading, onSelectSkill }: HomeViewProps) 
                         modelInvocable ? (
                           <ParkButton skill={skill} />
                         ) : (
-                          <button
+                          <Button
+                            variant="ghost"
                             className={ROW_ACTION_CLASS}
                             onClick={() => onSelectSkill(skill.name)}
                           >
                             Open
-                          </button>
+                          </Button>
                         )
                       }
                     />
@@ -919,8 +933,9 @@ function UpdatesGroup({
         count={updates.length}
         extra={
           updates.length > 1 && (
-            <button
-              className="border-0 bg-none p-0 text-small text-accent not-disabled:hover:underline disabled:text-text-quaternary disabled:cursor-not-allowed"
+            <Button
+              variant="link"
+              className="h-auto p-0 text-small disabled:text-text-quaternary"
               onClick={(e) => {
                 e.stopPropagation();
                 handleUpdateAll();
@@ -928,7 +943,7 @@ function UpdatesGroup({
               disabled={isUpdatingAll}
             >
               {isUpdatingAll ? "Updating…" : "Update all"}
-            </button>
+            </Button>
           )
         }
       />

--- a/apps/desktop/src/components/Shell/PageShell.tsx
+++ b/apps/desktop/src/components/Shell/PageShell.tsx
@@ -29,7 +29,7 @@ export function PageShell({
 }: PageShellProps) {
   return (
     <section
-      className={`mx-auto flex w-full flex-col gap-6 px-8 py-7 ${width === "narrow" ? "max-w-180" : "max-w-300"}`}
+      className={`mx-auto flex w-full flex-col gap-6 px-8 pt-9 pb-7 ${width === "narrow" ? "max-w-180" : "max-w-300"}`}
     >
       <header className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 flex-col gap-1">

--- a/apps/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Settings as SettingsIcon,
   Sun,
 } from "lucide-react";
+import { Button, Input } from "@skill-studio/ui";
 import { ownSkillsView, pluginSkillsView } from "@skill-studio/lib";
 import { defaultSkillListFilter } from "@skill-studio/lib";
 import { isFeatureEnabled } from "../../lib/feature-flags";
@@ -130,45 +131,46 @@ export function Sidebar({ snapshot, emittedSnapshotRevision, requestRescan }: Si
   const spinning = pendingRescanSnapshotRevision !== null;
 
   const itemClass = (active: boolean) =>
-    `grid h-[30px] w-full cursor-pointer grid-cols-[15px_minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 px-2.5 text-left text-body transition-colors ${
-      active
-        ? "bg-accent-soft text-text-primary"
-        : "bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+    `grid h-[30px] w-full grid-cols-[15px_minmax(0,1fr)_auto] gap-2 rounded-sm px-2.5 text-left text-body ${
+      active ? "bg-accent-soft text-text-primary" : "text-text-secondary"
     }`;
-  const iconButtonClass =
-    "flex size-6 cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent text-text-tertiary transition-colors hover:bg-bg-hover hover:text-text-primary";
+  const iconButtonClass = "rounded-sm text-text-tertiary";
 
   return (
-    <nav className="flex w-60 shrink-0 flex-col overflow-y-auto border-r border-border bg-bg-secondary">
-      <div className="flex flex-col gap-px px-2.5 pb-2.5 first:pt-3">
-        <input
+    <nav className="flex w-60 shrink-0 flex-col overflow-hidden border-r border-border bg-bg-secondary">
+      <div data-tauri-drag-region className="h-9 shrink-0" />
+      <div className="flex flex-col gap-px px-2.5 pt-1 pb-2.5">
+        <Input
           ref={searchInputRef}
           type="search"
           aria-label="Search skills"
-          className="h-8 rounded-sm border border-border bg-bg-primary px-3 text-body text-text-primary transition-colors duration-150 placeholder:text-text-quaternary focus-visible:border-border-focus"
           placeholder="Search skills…"
           value={skillListFilter.query}
           onChange={(e) => handleSearchChange(e.target.value)}
           onKeyDown={handleSearchKeyDown}
         />
-        <button
-          className="mt-1.5 flex h-[30px] cursor-pointer items-center justify-center gap-1.5 rounded-sm border-0 bg-accent-soft text-body text-text-primary transition-colors hover:text-accent-hover"
+        <Button
+          variant="default"
+          className="mt-1.5 h-[30px] gap-1.5 rounded-sm bg-accent-soft text-body text-text-primary"
           onClick={() => openAddSkillSheet()}
         >
           <Plus size={15} />
           <span>Add skill</span>
-        </button>
+        </Button>
       </div>
 
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
       <div className="flex flex-col gap-px px-2.5 pb-2.5 first:pt-3">
-        <button
+        <Button
+          variant="ghost"
           className={itemClass(anchorView.kind === "home")}
           onClick={() => setActiveView({ kind: "home" })}
         >
           <LayoutDashboard size={15} />
           <span className="min-w-0 truncate">Home</span>
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="ghost"
           className={itemClass(skillsActive)}
           onClick={() => {
             if (inParked) setSkillListFilter(defaultSkillListFilter());
@@ -182,9 +184,10 @@ export function Sidebar({ snapshot, emittedSnapshotRevision, requestRescan }: Si
               {skillsCount}
             </span>
           )}
-        </button>
+        </Button>
         {pluginCount > 0 && (
-          <button
+          <Button
+            variant="ghost"
             className={itemClass(anchorView.kind === "plugins")}
             onClick={() => setActiveView({ kind: "plugins" })}
           >
@@ -193,29 +196,32 @@ export function Sidebar({ snapshot, emittedSnapshotRevision, requestRescan }: Si
             <span className="text-right text-caption tabular-nums text-text-tertiary">
               {pluginCount}
             </span>
-          </button>
+          </Button>
         )}
-        <button
+        <Button
+          variant="ghost"
           className={itemClass(anchorView.kind === "activity")}
           onClick={() => setActiveView({ kind: "activity" })}
         >
           <ActivityIcon size={15} />
           <span className="min-w-0 truncate">Activity</span>
-        </button>
+        </Button>
         {packsEnabled && (
-          <button
+          <Button
+            variant="ghost"
             className={itemClass(anchorView.kind === "packs")}
             onClick={() => setActiveView({ kind: "packs" })}
           >
             <Package size={15} />
             <span className="min-w-0 truncate">Packs</span>
-          </button>
+          </Button>
         )}
       </div>
 
       {parkedCount > 0 && (
         <div className="flex flex-col gap-px px-2.5 pb-2.5 first:pt-3">
-          <button
+          <Button
+            variant="ghost"
             className={itemClass(anchorView.kind === "skills" && inParked)}
             onClick={() => {
               setSkillListFilter({ ...defaultSkillListFilter(), scope: "parked" });
@@ -227,51 +233,56 @@ export function Sidebar({ snapshot, emittedSnapshotRevision, requestRescan }: Si
             <span className="text-right text-caption tabular-nums text-text-tertiary">
               {parkedCount}
             </span>
-          </button>
+          </Button>
         </div>
       )}
+      </div>
 
       <div className="mt-auto flex select-none items-center justify-between gap-2 border-t border-border-subtle px-2.5 py-2">
         <TooltipControl content={rescanTooltip(snapshot?.scanned_at)}>
-          <button
-            type="button"
-            className="flex h-6 shrink-0 cursor-pointer items-center gap-1.5 rounded-sm border-0 bg-transparent px-1.5 text-caption text-text-tertiary transition-colors hover:enabled:bg-bg-hover hover:enabled:text-text-primary disabled:cursor-default"
+          <Button
+            variant="ghost"
+            size="xs"
+            className="shrink-0 gap-1.5 rounded-sm px-1.5 text-text-tertiary"
             onClick={handleRefresh}
             disabled={spinning}
             aria-label={spinning ? "Syncing installed skills" : "Sync installed skills"}
           >
             <RefreshCw size={13} className={spinning ? "animate-spin" : ""} />
             <span className="whitespace-nowrap">{spinning ? "Syncing…" : "Sync"}</span>
-          </button>
+          </Button>
         </TooltipControl>
         <div className="flex items-center gap-0.5">
           <TooltipControl content="Learn">
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon-xs"
               className={`${iconButtonClass} aria-[current=page]:bg-accent-softer aria-[current=page]:text-accent`}
               onClick={() => setActiveView({ kind: "learn" })}
               aria-current={anchorView.kind === "learn" ? "page" : undefined}
               aria-label="Learn"
             >
               <BookOpen size={13} />
-            </button>
+            </Button>
           </TooltipControl>
           <TooltipControl content="Settings">
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon-xs"
               className={`${iconButtonClass} aria-[current=page]:bg-accent-softer aria-[current=page]:text-accent`}
               onClick={() => setActiveView({ kind: "settings" })}
               aria-current={anchorView.kind === "settings" ? "page" : undefined}
               aria-label="Settings"
             >
               <SettingsIcon size={13} />
-            </button>
+            </Button>
           </TooltipControl>
           <TooltipControl
             content={resolvedTheme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
           >
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon-xs"
               className={iconButtonClass}
               onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
               aria-label={
@@ -279,7 +290,7 @@ export function Sidebar({ snapshot, emittedSnapshotRevision, requestRescan }: Si
               }
             >
               {resolvedTheme === "dark" ? <Moon size={13} /> : <Sun size={13} />}
-            </button>
+            </Button>
           </TooltipControl>
         </div>
       </div>

--- a/apps/desktop/src/components/SkillDetail/SkillPage.tsx
+++ b/apps/desktop/src/components/SkillDetail/SkillPage.tsx
@@ -368,7 +368,7 @@ export function SkillPage({
 
   if (!skill) {
     return (
-      <div className="mx-auto flex max-w-[1200px] flex-col gap-6 pt-7 pb-7 px-8">
+      <div className="mx-auto flex max-w-[1200px] flex-col gap-6 px-8 pt-9 pb-7">
         <div className="flex items-center gap-4">
           <Button
             variant="ghost"
@@ -386,7 +386,7 @@ export function SkillPage({
   }
 
   return (
-    <div className="mx-auto flex max-w-[1200px] flex-col gap-6 pt-7 pb-7 px-8">
+    <div className="mx-auto flex max-w-[1200px] flex-col gap-6 px-8 pt-9 pb-7">
       <InstalledSkillHeader
         skill={skill}
         deployment={deployment ?? undefined}

--- a/apps/desktop/src/components/SkillList/SkillListFilterBar.tsx
+++ b/apps/desktop/src/components/SkillList/SkillListFilterBar.tsx
@@ -168,14 +168,14 @@ export function SkillListFilterBar({
         <div className="flex" role="group" aria-label="Scope">
           <ToggleGroup
             variant="segmented"
-            className="rounded-r-none"
+            className="h-(--control-height) rounded-r-none"
             value={filter.scope === "all" || filter.scope === "global" ? [filter.scope] : []}
             onValueChange={(next) => singleSelectToggleValue<"all" | "global">(next, setScope)}
           >
-            <ToggleGroupItem value="all" className="px-3">
+            <ToggleGroupItem value="all" className="h-full px-3 text-body">
               All
             </ToggleGroupItem>
-            <ToggleGroupItem value="global" className="px-3">
+            <ToggleGroupItem value="global" className="h-full px-3 text-body">
               Global
             </ToggleGroupItem>
           </ToggleGroup>
@@ -314,6 +314,7 @@ export function SkillListFilterBar({
 
         <ToggleGroup
           variant="segmented"
+          className="h-(--control-height)"
           aria-label="View"
           value={[showCoverage ? "coverage" : "list"]}
           onValueChange={(next) =>
@@ -323,12 +324,16 @@ export function SkillListFilterBar({
           }
         >
           <TooltipControl content="List">
-            <ToggleGroupItem value="list" className="px-2.5" aria-label="List view">
+            <ToggleGroupItem value="list" className="h-full px-2.5" aria-label="List view">
               <List size={14} />
             </ToggleGroupItem>
           </TooltipControl>
           <TooltipControl content="Coverage matrix">
-            <ToggleGroupItem value="coverage" className="px-2.5" aria-label="Coverage matrix view">
+            <ToggleGroupItem
+              value="coverage"
+              className="h-full px-2.5"
+              aria-label="Coverage matrix view"
+            >
               <LayoutGrid size={14} />
             </ToggleGroupItem>
           </TooltipControl>

--- a/packages/marketing/index.html
+++ b/packages/marketing/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Find installed agent skills, compare copies, and choose which agents and projects receive them."
+      content="A desktop app for managing agent skills. Find installed copies, compare changes, and choose where to install."
     />
     <title>Skill Studio | Manage agent skills</title>
   </head>

--- a/packages/marketing/src/MarketingSite.tsx
+++ b/packages/marketing/src/MarketingSite.tsx
@@ -62,7 +62,7 @@ export function MarketingSite() {
   };
 
   return (
-    <div {...stylex.props(getPaletteTheme("mono"))}>
+    <div {...stylex.props(getPaletteTheme("violet"))}>
       <CommandCenter theme={theme} onToggleTheme={toggleTheme} />
     </div>
   );

--- a/packages/marketing/src/MarketingSite.tsx
+++ b/packages/marketing/src/MarketingSite.tsx
@@ -53,8 +53,11 @@ export function MarketingSite() {
           ],
         },
         {
-          duration: 520,
-          easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+          // A near-linear start keeps the first frames inside the icon, so the reveal reads as
+          // growing out of the button. An expo-out curve reaches ~90% radius in 150ms and then
+          // crawls, which reads as a mid-way freeze.
+          duration: 560,
+          easing: "cubic-bezier(0.4, 0, 0.2, 1)",
           pseudoElement: "::view-transition-new(root)",
         },
       );

--- a/packages/marketing/src/PaletteThemes.stylex.ts
+++ b/packages/marketing/src/PaletteThemes.stylex.ts
@@ -119,7 +119,7 @@ const violetTheme = stylex.createTheme(paletteVars, {
   darkRaised: "oklch(0.225 0.025 290)",
   darkText: "oklch(0.97 0.008 290)",
   darkMuted: "oklch(0.73 0.03 290)",
-  darkBorder: "oklch(0.271 0.009 286)",
+  darkBorder: "oklch(0.271 0.009 290)",
   darkAccent: "oklch(0.668 0.176 293)",
   darkAccentHover: "oklch(0.725 0.145 293)",
   darkAccentSoft: "oklch(0.668 0.176 293 / 0.16)",

--- a/packages/marketing/src/ProductMock.tsx
+++ b/packages/marketing/src/ProductMock.tsx
@@ -1558,7 +1558,7 @@ const styles = stylex.create({
     outline: "none",
     padding: 0,
     width: "100%",
-    "@media (max-width: 680px)": { fontSize: 15 },
+    "@media (max-width: 680px)": { fontSize: 16 },
   },
   addSkill: {
     alignItems: "center",
@@ -1658,6 +1658,7 @@ const styles = stylex.create({
     scrollbarWidth: "none",
     "::-webkit-scrollbar": { display: "none" },
     "@media (max-width: 680px)": { height: 424, width: "100%" },
+    "@media (prefers-reduced-motion: reduce)": { animationName: "none" },
   },
   page: {
     display: "flex",
@@ -1774,7 +1775,7 @@ const styles = stylex.create({
     width: "100%",
     ":focus": { borderColor: tokens.accent },
   },
-  addSkillHelp: { color: tokens.faint, fontSize: 10, lineHeight: 1.4 },
+  addSkillHelp: { color: tokens.faint, fontSize: 12, lineHeight: 1.4 },
   methodPicker: { display: "flex" },
   methodButton: {
     backgroundColor: "transparent",
@@ -1833,7 +1834,7 @@ const styles = stylex.create({
   installTargetPath: {
     color: tokens.faint,
     fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-    fontSize: 10,
+    fontSize: 12,
   },
   installSwitch: {
     backgroundColor: tokens.raised,
@@ -2216,7 +2217,7 @@ const styles = stylex.create({
   location: { alignItems: "center", color: tokens.muted, display: "flex", gap: 6, minWidth: 0 },
   agentStack: { alignItems: "center", display: "flex", gap: 4 },
   number: { color: tokens.muted, fontVariantNumeric: "tabular-nums", textAlign: "right" },
-  empty: { color: tokens.muted, fontSize: 10, textAlign: "center" },
+  empty: { color: tokens.muted, fontSize: 12, textAlign: "center" },
   pluginGroups: { display: "flex", flexDirection: "column", gap: 16 },
   pluginGroup: {
     backgroundColor: "transparent",
@@ -2490,6 +2491,7 @@ const styles = stylex.create({
     lineHeight: 1.5,
     margin: 0,
     maxWidth: "65ch",
+    textWrap: "pretty",
   },
   chips: { display: "flex", gap: 6 },
   chip: {

--- a/packages/marketing/src/marketing-site.css
+++ b/packages/marketing/src/marketing-site.css
@@ -23,6 +23,7 @@ body {
   color-scheme: dark;
   min-width: 320px;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+  font-synthesis: none;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -56,6 +57,18 @@ button {
 
 ::selection {
   background: rgba(255, 255, 255, 0.16);
+}
+
+@media (prefers-color-scheme: light) {
+  html:not([data-site-theme="dark"]) ::selection {
+    background: rgba(0, 0, 0, 0.12);
+    color: inherit;
+  }
+}
+
+html[data-site-theme="light"] ::selection {
+  background: rgba(0, 0, 0, 0.12);
+  color: inherit;
 }
 
 ::view-transition-old(root),

--- a/packages/marketing/src/variants/CommandCenter.tsx
+++ b/packages/marketing/src/variants/CommandCenter.tsx
@@ -1,4 +1,3 @@
-import { useRef, type PointerEvent } from "react";
 import * as stylex from "@stylexjs/stylex";
 import { Code2 } from "lucide-react";
 
@@ -40,31 +39,6 @@ function DownloadButton({ theme }: { theme: SiteTheme }) {
 }
 
 export function CommandCenter({ theme, onToggleTheme }: CommandCenterProps) {
-  const productHalo = useRef<HTMLDivElement>(null);
-
-  const moveProductHalo = (event: PointerEvent<HTMLDivElement>) => {
-    if (
-      event.pointerType !== "mouse" ||
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches
-    ) {
-      return;
-    }
-    const bounds = event.currentTarget.getBoundingClientRect();
-    const x = (event.clientX - bounds.left - bounds.width / 2) * 0.05;
-    const y = (event.clientY - bounds.top - bounds.height / 2) * 0.05;
-    if (productHalo.current) {
-      productHalo.current.style.transform = `translate3d(${x}px, ${y}px, 0) scale(1.04)`;
-      productHalo.current.style.opacity = "0.86";
-    }
-  };
-
-  const resetProductHalo = () => {
-    if (productHalo.current) {
-      productHalo.current.style.transform = "translate3d(0, 0, 0) scale(1)";
-      productHalo.current.style.opacity = "0.62";
-    }
-  };
-
   return (
     <div id="top" {...stylex.props(styles.page, theme === "light" && lightSiteTheme)}>
       <header {...stylex.props(styles.header)}>
@@ -107,18 +81,8 @@ export function CommandCenter({ theme, onToggleTheme }: CommandCenterProps) {
             </div>
           </div>
 
-          <div
-            id="product"
-            onPointerMove={moveProductHalo}
-            onPointerLeave={resetProductHalo}
-            {...stylex.props(styles.productWrap)}
-          >
-            <div
-              ref={productHalo}
-              data-product-halo=""
-              {...stylex.props(styles.productHalo)}
-              aria-hidden="true"
-            />
+          <div id="product" {...stylex.props(styles.productWrap)}>
+            <div {...stylex.props(styles.productHalo)} aria-hidden="true" />
             <ProductMock theme={theme} onToggleTheme={onToggleTheme} />
           </div>
         </section>
@@ -246,6 +210,7 @@ const styles = stylex.create({
     lineHeight: 1.6,
     margin: "30px 0 28px",
     maxWidth: "54ch",
+    textWrap: "pretty",
     "@media (max-width: 600px)": { maxWidth: "34ch" },
   },
   actions: {
@@ -281,7 +246,6 @@ const styles = stylex.create({
       ":hover": {
         backgroundColor: siteTokens.accentHover,
         boxShadow: "0 1px 0 oklch(1 0 0 / .35) inset, 0 14px 38px oklch(0 0 0 / .38)",
-        transform: "scale(1.015)",
       },
       ":hover:active": {
         boxShadow: "0 1px 0 oklch(1 0 0 / .18) inset, 0 4px 12px oklch(0 0 0 / .24)",
@@ -344,7 +308,6 @@ const styles = stylex.create({
     opacity: 0.62,
     pointerEvents: "none",
     position: "absolute",
-    transition: "opacity 220ms ease, transform 600ms cubic-bezier(0.19, 1, 0.22, 1)",
   },
   agentProof: {
     alignItems: "center",

--- a/packages/ui/src/lib/cn.ts
+++ b/packages/ui/src/lib/cn.ts
@@ -6,7 +6,31 @@
 // ============================================================================
 
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// The app names its font sizes (--text-caption … --text-display). Without registering them,
+// tailwind-merge keeps a base class such as `text-sm` next to a caller's `text-body` and the
+// base wins, so the token never applies.
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "caption",
+            "small",
+            "body",
+            "emphasis",
+            "heading",
+            "heading-lg",
+            "title",
+            "display",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));


### PR DESCRIPTION
## Summary

Three design commits, independent of the core-crate PR.

- **Marketing site**: Violet palette to match the desktop accent, pointer-tracking hero halo and button hover scale removed, reduced-motion gates, `text-wrap: pretty`, smallest helper text raised to 12px, font-synthesis and light-mode selection colour set.
- **Desktop window chrome**: macOS overlay titlebar with drag strips in the sidebar and main pane (`core:window:allow-start-dragging`), stable scrollbar gutter so stat-card toggles no longer shift content, doubled inset border on selected stat cards dropped, sidebar nav scrolls inside the frame with the footer pinned, `AGENTS.md` trimmed to top-level workspaces.
- **Page spacing and toolbars**: the 36px drag region is folded into the page top padding so titles sit ~28px from the window edge instead of ~64px; the skill-list scope and view toggle groups use `--control-height` to match the Sort trigger; `cn.ts` registers the app's named font sizes with tailwind-merge so `text-body` overrides a primitive's `text-sm`.

## Test plan

- [ ] `npm run typecheck && npm run lint`
- [ ] Desktop: window drags from the titlebar strip; dashboard, skill list, and skill page titles align at the same top offset; filter bar controls share one height
- [ ] Marketing site (`packages/marketing`): violet accent, no hero halo, motion off under reduced-motion

Created with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly visual, layout, and documentation; Tauri window permissions are additive and do not touch skill lifecycle or auth.
> 
> **Overview**
> Aligns **desktop window chrome**, **page layout**, **shared UI usage**, and the **marketing site** with the violet desktop accent.
> 
> **Desktop:** Tauri gets macOS **overlay title bar** (`titleBarStyle: Overlay`), `core:window:allow-start-dragging`, and **`data-tauri-drag-region`** strips in the sidebar and main pane so the window drags without extra top padding. Main content uses **`scrollbar-gutter: stable`**; **PageShell** / skill page top padding shifts to **`pt-9`** so titles sit ~28px from the window edge. The sidebar **scrolls inside the frame** with the footer pinned. Home and sidebar controls move from raw `<button>` / `<input>` to **`@skill-studio/ui`** `Button` and `Input` (per **AGENTS.md** and `anti-slop/no-raw-form-elements`). Skill list **scope/view toggles** use **`h-(--control-height)`** to match Sort; **`cn.ts`** registers app **`text-*`** tokens with tailwind-merge so overrides like `text-body` win over primitive defaults.
> 
> **Marketing:** Default palette switches **mono → violet**; hero **pointer-tracking halo** and download **hover scale** removed; theme **view-transition** easing/duration tweaked; helper text bumped to **12px**, **`text-wrap: pretty`**, reduced-motion on mock animations, light-mode **selection** and **meta description** updates.
> 
> **Docs:** **AGENTS.md** project tree is workspace-level only and documents the UI primitive rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d837414ac6450ebac0381c8b7403a8f396cbaa7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->