### PR TITLE
ux: Stack skill row with muted harness discs

### DIFF
--- a/apps/desktop/src/components/Home/HomeView.tsx
+++ b/apps/desktop/src/components/Home/HomeView.tsx
@@ -30,7 +30,6 @@ import { ownSkillsView } from "@skill-studio/lib";
 import { formatRelativeTime, formatTokens, shortSha } from "@skill-studio/lib";
 import { skillsWithUpdates } from "@skill-studio/lib";
 import type {
-  AgentId,
   InstalledSkill,
   InvocationPolicy,
   LifecycleTarget,
@@ -39,7 +38,8 @@ import type {
 } from "@skill-studio/lib";
 import { useAppStore } from "../../store/appStore";
 import { PageShell } from "../Shell/PageShell";
-import { HarnessIcon, harnessIdFromLabel } from "../ui/HarnessIcon";
+import { DEFAULT_HARNESS_LIST } from "../SkillList/skill-row-state";
+import { HarnessStack } from "../SkillList/HarnessStack";
 import { InfoPopover } from "../ui/InfoPopover";
 import { MaterializeRootDialog } from "../ui/MaterializeRootDialog";
 import { TooltipControl } from "../ui/TooltipControl";
@@ -64,35 +64,6 @@ interface HomeViewProps {
   snapshot: SkillSnapshot | undefined;
   isLoading: boolean;
   onSelectSkill: (name: string) => void;
-}
-
-/** The harness marks for one skill's deployments - muted when every deployment for that harness is disabled or parked. */
-function harnessBadges(skill: InstalledSkill) {
-  const byHarness = new Map<AgentId | "shared", boolean[]>();
-  for (const deployment of skill.deployments) {
-    const id = harnessIdFromLabel(deployment.agent);
-    if (!id) continue;
-    const active = !deployment.disabled && deployment.scope !== "parked";
-    byHarness.set(id, [...(byHarness.get(id) ?? []), active]);
-  }
-  return [...byHarness.entries()].map(([id, activeFlags]) => ({
-    id,
-    muted: !activeFlags.some(Boolean),
-  }));
-}
-
-function HarnessBadges({ skill }: { skill: InstalledSkill }) {
-  const badges = harnessBadges(skill);
-  if (badges.length === 0) return null;
-  return (
-    <span className="inline-flex shrink-0 gap-[5px]">
-      {badges.map(({ id, muted }) => (
-        <span key={id} className="inline-flex text-text-tertiary">
-          <HarnessIcon harness={id} size={13} muted={muted} />
-        </span>
-      ))}
-    </span>
-  );
 }
 
 /** One row of any inbox group: severity dot, name + harness marks, detail, one action. */
@@ -123,7 +94,7 @@ function InboxRow({
         >
           {skill.name}
         </Button>
-        <HarnessBadges skill={skill} />
+        <HarnessStack skill={skill} harnessList={DEFAULT_HARNESS_LIST} />
       </span>
       <span className="truncate text-small text-text-tertiary">{detail}</span>
       {action}

--- a/apps/desktop/src/components/SkillList/HarnessMark.tsx
+++ b/apps/desktop/src/components/SkillList/HarnessMark.tsx
@@ -1,0 +1,168 @@
+// ============================================================================
+// HarnessMark - shared harness/Universal-folder marks: a fixed-size box that
+// shows the harness's brand icon, dimmed to the `--color-icon-muted` tone
+// when the harness doesn't reach the skill, badged with a small link glyph
+// anchored to the icon when it reaches the skill only through the Universal
+// folder. Every reached mark has a one-line tooltip naming the harness and
+// how it reaches the skill, since the 11px badge is too small to carry that
+// alone.
+// ============================================================================
+
+import { Bot, Layers, Link2, Link2Off } from "lucide-react";
+import type { AgentId } from "@skill-studio/lib";
+import { HarnessIcon } from "../ui/HarnessIcon";
+import { RichTooltip } from "../ui/RichTooltip";
+import type { HarnessReach, Universal } from "./skill-row-state";
+
+/** The ids `HarnessIcon` has a brand SVG for. */
+const KNOWN_HARNESS_IDS = new Set<AgentId | "shared">([
+  "claude-code",
+  "codex",
+  "open-code",
+  "pi",
+  "cursor",
+  "grok-build",
+  "shared",
+]);
+
+/** `HarnessIcon` renders nothing for an id it has no brand SVG for; this
+ * fallback draws lucide's `Bot` instead so every harness always has an icon
+ * to show. */
+export function HarnessGlyph({
+  harness,
+  size,
+  muted,
+}: {
+  harness: AgentId;
+  size: number;
+  muted?: boolean;
+}) {
+  if (KNOWN_HARNESS_IDS.has(harness))
+    return <HarnessIcon harness={harness} size={size} muted={muted} />;
+  return (
+    <Bot size={size} aria-hidden style={muted ? { color: "var(--color-icon-muted)" } : undefined} />
+  );
+}
+
+function harnessMarkAriaLabel(reach: HarnessReach): string {
+  const how =
+    reach.how === "linked"
+      ? "link to the Universal folder"
+      : reach.how === "broken"
+        ? "broken link"
+        : reach.how === "universal"
+          ? "source in the Universal folder"
+          : "own copy";
+  return `${reach.label} · ${how}`;
+}
+
+/** One line per reached harness: `<glyph> <label> · <how>[ · <state>]` - the
+ * words the 11px badge cannot carry on its own. The how-word (linked /
+ * source / own copy) always shows; a broken link replaces it in the error
+ * tone, and disabled or parked follows it in the warning tone. */
+function harnessMarkTooltip(reach: HarnessReach, parked: boolean) {
+  const how =
+    reach.how === "broken"
+      ? { text: "link broken", tone: "text-error" }
+      : reach.how === "linked"
+        ? { text: "linked to Universal folder", tone: "text-text-tertiary" }
+        : reach.how === "universal"
+          ? { text: "source in Universal folder", tone: "text-text-tertiary" }
+          : { text: "own copy", tone: "text-text-tertiary" };
+  const state = parked ? "parked" : reach.disabled ? "disabled" : null;
+  return (
+    <span className="flex items-center gap-1.5 text-small">
+      <HarnessGlyph harness={reach.harness} size={14} />
+      <span>{reach.label}</span>
+      <span className={how.tone}>· {how.text}</span>
+      {state && <span className="text-warning">· {state}</span>}
+    </span>
+  );
+}
+
+/** One harness's mark: unreached is the harness's own icon dimmed to
+ * `--color-icon-muted` at `opacity-60` - readable as a second state next to a
+ * full-tone icon rather than "two shades" - with no tooltip, since there's
+ * nothing to say about a harness that isn't there. Reached is the brand icon
+ * at full tone, badged with a small link (or broken-link) glyph anchored to
+ * the icon itself (not the slot) when the reach is only through the
+ * Universal folder, so every harness's badge lands at the same offset from
+ * its icon's corner. */
+export function HarnessMark({
+  reach,
+  size = 13,
+  parked = false,
+}: {
+  reach: HarnessReach;
+  size?: number;
+  /** The whole skill is parked: every disc takes the disabled treatment and says so. */
+  parked?: boolean;
+}) {
+  if (!reach.reached) {
+    return (
+      <span
+        className="relative inline-flex size-5 items-center justify-center opacity-60"
+        aria-hidden
+      >
+        <HarnessGlyph harness={reach.harness} size={size} muted />
+      </span>
+    );
+  }
+  const badge = reach.how === "linked" || reach.how === "broken" ? reach.how : null;
+  // A disabled or parked glyph is always muted.
+  const glyphMuted = reach.disabled || parked;
+  const mark = (
+    <span
+      className="group relative inline-flex size-5 items-center justify-center"
+      aria-label={harnessMarkAriaLabel(reach)}
+    >
+      <span className="relative inline-flex" style={{ width: size, height: size }}>
+        <HarnessGlyph harness={reach.harness} size={size} muted={glyphMuted} />
+        {badge && (
+          <span className="absolute -right-1 -bottom-1 inline-flex size-2.5 items-center justify-center rounded-full bg-bg-primary group-hover:bg-bg-secondary">
+            {badge === "linked" ? (
+              <Link2 size={7} className="text-text-secondary" aria-hidden />
+            ) : (
+              <Link2Off size={7} className="text-error" aria-hidden />
+            )}
+          </span>
+        )}
+      </span>
+    </span>
+  );
+  return <RichTooltip content={harnessMarkTooltip(reach, parked)}>{mark}</RichTooltip>;
+}
+
+/** The Universal folder's own mark: present is the folder's `Layers` glyph
+ * at full tone; absent is the same glyph dimmed to `--color-icon-muted` at
+ * `opacity-60`. Present shows a one-line "Universal folder" tooltip so the
+ * Layers glyph is named. */
+export function UniversalMark({ universal, size = 13 }: { universal: Universal; size?: number }) {
+  if (!universal.present) {
+    return (
+      <span
+        className="relative inline-flex size-5 items-center justify-center opacity-60"
+        aria-hidden
+      >
+        <Layers size={size} style={{ color: "var(--color-icon-muted)" }} />
+      </span>
+    );
+  }
+  return (
+    <RichTooltip
+      content={
+        <span className="flex items-center gap-1.5 text-small">
+          <Layers size={14} aria-hidden />
+          Universal folder
+        </span>
+      }
+    >
+      <span
+        className="relative inline-flex size-5 items-center justify-center"
+        aria-label="Universal folder"
+      >
+        <Layers size={size} className="text-text-primary" aria-hidden />
+      </span>
+    </RichTooltip>
+  );
+}

--- a/apps/desktop/src/components/SkillList/HarnessStack.tsx
+++ b/apps/desktop/src/components/SkillList/HarnessStack.tsx
@@ -1,0 +1,95 @@
+// ============================================================================
+// HarnessStack - the avatar-group stack: the reached harnesses overlap into
+// one shape, the Universal folder leads when present, and past `MAX_DISCS`
+// the rest fold into a "+N" disc.
+// ============================================================================
+
+import type { ReactNode } from "react";
+import type { InstalledSkill } from "@skill-studio/lib";
+import { RichTooltip } from "../ui/RichTooltip";
+import { HarnessGlyph, HarnessMark, UniversalMark } from "./HarnessMark";
+import { whereFacts } from "./skill-row-state";
+import type { HarnessListEntry, HarnessReach } from "./skill-row-state";
+
+/** Past this many discs (the Universal folder counted as one), the rest fold into a "+N" disc. */
+const MAX_DISCS = 5;
+
+/** The "+N" disc's tooltip: one line per hidden harness, glyph and label only - no how word,
+ * since the row already shows how. */
+function OverflowTooltip({ overflow }: { overflow: HarnessReach[] }) {
+  return (
+    <div className="flex flex-col gap-1 text-small">
+      {overflow.map((reach) => (
+        <span key={reach.harness} className="flex items-center gap-1.5 text-text-tertiary">
+          <HarnessGlyph harness={reach.harness} size={14} />
+          {reach.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** One disc in the stack: the avatar-group convention - `size-5 rounded-full
+ * bg-bg-secondary`, ringed in the page's own background colour so the ring is
+ * what visually separates neighbours rather than a border against the fill,
+ * `-ml-1` (4px) overlap after the first so the group reads as one shape until
+ * a disc is singled out on hover, and `group-hover:ring-bg-secondary` so the
+ * row hover doesn't leave the ring looking detached from its fill. A disabled
+ * or parked disc only mutes its glyph - `HarnessMark` already does that, so
+ * the disc itself needs no separate disabled treatment. */
+function Disc({ first, children }: { first: boolean; children: ReactNode }) {
+  return (
+    <span
+      className={`relative inline-flex size-5 items-center justify-center rounded-full bg-bg-secondary ring-2 ring-bg-primary group-hover:ring-bg-secondary hover:z-10 ${
+        first ? "" : "-ml-1"
+      }`}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** The reached-harness stack: the Universal folder disc first when present, then one disc per
+ * reached harness up to `MAX_DISCS`, then a "+N" overflow disc. */
+export function HarnessStack({
+  skill,
+  harnessList,
+}: {
+  skill: InstalledSkill;
+  harnessList: HarnessListEntry[];
+}) {
+  const facts = whereFacts(skill, harnessList);
+  const { universal, harnesses } = facts;
+  const reached = harnesses.filter((h) => h.reached);
+  if (!universal.present && reached.length === 0) {
+    return <span className="text-small text-text-tertiary">—</span>;
+  }
+  const discs: ReactNode[] = [];
+  if (universal.present) {
+    discs.push(
+      <Disc key="universal" first={discs.length === 0}>
+        <UniversalMark universal={universal} size={11} />
+      </Disc>,
+    );
+  }
+  const budget = MAX_DISCS - discs.length;
+  const shown = reached.slice(0, budget);
+  const overflow = reached.slice(budget);
+  for (const reach of shown) {
+    discs.push(
+      <Disc key={reach.harness} first={discs.length === 0}>
+        <HarnessMark reach={reach} size={11} parked={skill.parked} />
+      </Disc>,
+    );
+  }
+  if (overflow.length > 0) {
+    discs.push(
+      <Disc key="overflow" first={discs.length === 0}>
+        <RichTooltip content={<OverflowTooltip overflow={overflow} />}>
+          <span className="text-caption tabular-nums text-text-tertiary">+{overflow.length}</span>
+        </RichTooltip>
+      </Disc>,
+    );
+  }
+  return <span className="inline-flex items-center">{discs}</span>;
+}

--- a/apps/desktop/src/components/SkillList/SkillListTable.tsx
+++ b/apps/desktop/src/components/SkillList/SkillListTable.tsx
@@ -4,24 +4,37 @@
 // ============================================================================
 
 import { useRef, useState } from "react";
-import type { KeyboardEvent } from "react";
-import { formatTokens, pluginLabelForSkill } from "@skill-studio/lib";
+import type { CSSProperties, KeyboardEvent } from "react";
 import type { InstalledSkill, PackMember, SkillInvocationStats } from "@skill-studio/lib";
 import { Button } from "@skill-studio/ui";
 import { isFeatureEnabled } from "../../lib/feature-flags";
+import { parkSkill, unparkSkill } from "../../lib/skill-api";
+import { lifecycleTargetForPark } from "../../lib/skill-lifecycle-target";
 import type { SortMode } from "../../lib/skill-list-sort";
 import { useAppStore } from "../../store/appStore";
 import { PackNamePrompt } from "../Packs/PackNamePrompt";
 import { CheckboxControl } from "../ui/CheckboxControl";
+import { HarnessStack } from "./HarnessStack";
+import {
+  HEADER_CELL_CLASS,
+  LeadingCell,
+  ROW_CLASS,
+  selectedRowClass,
+  SkillNameCell,
+  sortRows,
+  TokenPairCell,
+  TokenPairHeader,
+} from "./SkillRowCells";
+import type { TokenSortKey } from "./SkillRowCells";
 import { SkillLocationCell } from "./SkillLocationCell";
-import { TooltipControl } from "../ui/TooltipControl";
+import { DEFAULT_HARNESS_LIST, whereFacts } from "./skill-row-state";
 
-/** "User only" / "Model only" chip label, `null` for the default "both" policy. */
-function invocationChipLabel(invocation: InstalledSkill["invocation"]): string | null {
-  if (invocation === "user-only") return "User only";
-  if (invocation === "model-only") return "Model only";
-  return null;
-}
+/** The row's leading-glyph hit box, and the icon it holds - fixed sizes. */
+const GLYPH_HIT = 28;
+const GLYPH_SIZE = 14;
+
+/** Every skill row's column template: leading glyph, name, location, harnesses, tokens. */
+const COLUMNS = "[grid-template-columns:var(--glyph-hit)_minmax(0,1fr)_160px_148px_104px]";
 
 interface SkillListTableProps {
   skills: InstalledSkill[];
@@ -41,11 +54,10 @@ interface SkillListTableProps {
 }
 
 /**
- * Toolbar (Select, filter, sort) above a list of skill rows: name, one-line
- * description, location chips, 30-day use count and SKILL.md token count.
- * Clicking a row opens the skill, unless selection mode is on, where it
- * toggles the row instead. Selection and packs sit behind the "skill-packs"
- * feature flag.
+ * Toolbar (Select, filter, sort) above a list of skill rows: the state
+ * glyph, name, disk location, harness stack, and token pair. Clicking a row
+ * opens the skill, unless selection mode is on, where it toggles the row
+ * instead. Selection and packs sit behind the "skill-packs" feature flag.
  */
 export function SkillListTable({
   skills,
@@ -59,6 +71,7 @@ export function SkillListTable({
   onAddSkill,
 }: SkillListTableProps) {
   const [showPackPrompt, setShowPackPrompt] = useState(false);
+  const [tokenSort, setTokenSort] = useState<TokenSortKey>("full");
   const packsEnabled = isFeatureEnabled("skill-packs");
   const statsBySkill = new Map(stats.map((s) => [s.skill, s]));
   const selectedPaths = useAppStore((state) => state.selectedSkillPaths);
@@ -68,6 +81,7 @@ export function SkillListTable({
   const selectionMode = useAppStore((state) => state.selectionMode);
   const enterSelectionMode = useAppStore((state) => state.enterSelectionMode);
   const exitSelectionMode = useAppStore((state) => state.exitSelectionMode);
+  const addToast = useAppStore((state) => state.addToast);
   /** Index of the last row checked by click (not shift-click), for shift-click range-select. */
   const lastCheckedIndexRef = useRef<number | null>(null);
 
@@ -75,18 +89,7 @@ export function SkillListTable({
   const rowPath = (skill: InstalledSkill): string | undefined =>
     deploymentPathForSkill?.(skill) ?? skill.deployments[0]?.path;
 
-  const rows = [...skills];
-  if (sort === "name") {
-    rows.sort((a, b) => a.name.localeCompare(b.name));
-  } else if (sort === "used") {
-    rows.sort(
-      (a, b) =>
-        (statsBySkill.get(b.name)?.last_30_days ?? 0) -
-        (statsBySkill.get(a.name)?.last_30_days ?? 0),
-    );
-  } else {
-    rows.sort((a, b) => b.skill_md_tokens - a.skill_md_tokens);
-  }
+  const rows = sortRows(skills, sort, statsBySkill, tokenSort);
 
   const allVisibleSelected =
     rows.length > 0 && rows.every((s) => selectedPaths.has(rowPath(s) ?? ""));
@@ -138,22 +141,44 @@ export function SkillListTable({
     }
   }
 
+  /** Park/Unpark act on the deployment target `HomeView` uses; every other fix (Fix YAML, Fix
+   * link, Compare, Convert, Keep, Pull latest) opens the skill's own detail, since those flows
+   * live there. */
+  async function handleAct(label: string, skill: InstalledSkill) {
+    if (label !== "Park" && label !== "Unpark") {
+      onSelectSkill(skill.name, deploymentPathForSkill?.(skill));
+      return;
+    }
+    try {
+      if (label === "Park") await parkSkill(lifecycleTargetForPark(skill));
+      else await unparkSkill(lifecycleTargetForPark(skill));
+      addToast({
+        type: "success",
+        title: label === "Park" ? `Parked ${skill.name}` : `Unparked ${skill.name}`,
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        title: label === "Park" ? "Couldn't park skill" : "Couldn't unpark skill",
+        message: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }
+
   return (
-    <div className="flex flex-col gap-3" onKeyDown={handleTableKeyDown}>
+    <div
+      className="flex flex-col gap-3"
+      style={
+        // SAFETY: `--glyph-hit` is a custom property, not a known CSSProperties key; React
+        // passes it through to the style attribute as-is.
+        { "--glyph-hit": `${GLYPH_HIT}px` } as CSSProperties
+      }
+      onKeyDown={handleTableKeyDown}
+    >
       {(selectionMode || packsEnabled) && (
         <div className="flex items-center gap-2">
           {selectionMode ? (
             <>
-              {/* The header checkbox sits in the same w-11 rail as the row
-                  checkboxes below, so entering selection mode doesn't shift it. */}
-              <div className="flex w-11 shrink-0 items-center justify-center [&_.checkbox-control-root]:before:absolute [&_.checkbox-control-root]:before:-inset-3 [&_.checkbox-control-root]:before:content-['']">
-                <CheckboxControl
-                  checked={allVisibleSelected}
-                  onCheckedChange={handleHeaderCheckboxChange}
-                  disabled={rows.length === 0}
-                  ariaLabel="Select all visible skills"
-                />
-              </div>
               <span className="text-small text-text-secondary">{selectedPaths.size} selected</span>
               <Button
                 size="sm"
@@ -215,105 +240,58 @@ export function SkillListTable({
           )}
         </div>
       ) : (
-        <div className="flex flex-col gap-1.5">
-          <div className="flex items-stretch">
-            {selectionMode && <span className="w-11 shrink-0" />}
-            <div className="grid min-w-0 flex-1 items-center gap-3 border border-transparent px-3 [grid-template-columns:minmax(0,1.2fr)_minmax(0,1.8fr)_140px_48px_64px]">
-              <span />
-              <span />
-              <span />
-              <TooltipControl content="Invocations in the last 30 days">
-                <span className="text-right text-caption text-text-tertiary">Uses</span>
-              </TooltipControl>
-              <TooltipControl content="SKILL.md tokens the model reads">
-                <span className="text-right text-caption text-text-tertiary">Tokens</span>
-              </TooltipControl>
+        <div className="overflow-hidden rounded-md border border-border">
+          <div className="flex items-center border-b border-border-subtle bg-bg-secondary px-3">
+            <div className={`grid flex-1 items-center gap-x-3 ${HEADER_CELL_CLASS} ${COLUMNS}`}>
+              {selectionMode ? (
+                <CheckboxControl
+                  checked={allVisibleSelected}
+                  onCheckedChange={handleHeaderCheckboxChange}
+                  disabled={rows.length === 0}
+                  ariaLabel="Select all visible skills"
+                />
+              ) : (
+                <span aria-hidden />
+              )}
+              <span>Skill</span>
+              <span>Location</span>
+              <span>Harnesses</span>
+              <TokenPairHeader sortKey={tokenSort} onSort={setTokenSort} />
             </div>
           </div>
           {rows.map((skill, index) => {
-            const stat = statsBySkill.get(skill.name);
             const selected = skill.name === selectedSkillName;
             return (
-              <div key={skill.name} className="flex items-stretch">
-                {selectionMode && (
-                  <label
-                    className="flex w-11 shrink-0 cursor-pointer items-center justify-center"
-                    aria-label={`Select ${skill.name}`}
-                  >
-                    <CheckboxControl
-                      checked={selectedPaths.has(rowPath(skill) ?? "")}
-                      onCheckedChange={(_checked, eventDetails) => {
-                        // SAFETY: the underlying event is a pointer or keyboard event, both of which carry `shiftKey`.
-                        const shiftKey = (eventDetails.event as MouseEvent | KeyboardEvent)
-                          .shiftKey;
-                        handleRowCheckboxClick(index, shiftKey);
-                      }}
-                    />
-                  </label>
-                )}
-                <Button
-                  variant="ghost"
-                  className={`grid h-11 min-w-0 flex-1 gap-3 overflow-hidden rounded-md border border-border bg-bg-secondary px-3 justify-start text-left [grid-template-columns:minmax(0,1.2fr)_minmax(0,1.8fr)_140px_48px_64px] ${
-                    selected
-                      ? "border-accent bg-accent-softer shadow-[inset_2px_0_0_var(--color-accent)]"
-                      : ""
-                  }`}
-                  onClick={(e) => {
-                    if (selectionMode && e.shiftKey) {
-                      handleRowCheckboxClick(index, true);
-                      return;
-                    }
-                    handleRowClick(index, skill);
+              <div
+                key={skill.name}
+                className={`${ROW_CLASS} gap-x-3 px-3 ${COLUMNS} hover:bg-bg-secondary ${selectedRowClass(
+                  selected,
+                )} ${skill.parked ? "text-text-tertiary" : ""}`}
+                onClick={(e) => {
+                  if (selectionMode && e.shiftKey) {
+                    handleRowCheckboxClick(index, true);
+                    return;
+                  }
+                  handleRowClick(index, skill);
+                }}
+              >
+                <LeadingCell
+                  skill={skill}
+                  selectionMode={selectionMode}
+                  checked={selectedPaths.has(rowPath(skill) ?? "")}
+                  onCheckedChange={(_checked, eventDetails) => {
+                    // SAFETY: the underlying event is a pointer or keyboard event, both of which carry `shiftKey`.
+                    const shiftKey = (eventDetails.event as MouseEvent | KeyboardEvent).shiftKey;
+                    handleRowCheckboxClick(index, shiftKey);
                   }}
-                >
-                  <span className="flex min-w-0 items-center gap-1.5">
-                    <span
-                      className="truncate text-body font-semibold text-text-primary"
-                      title={skill.name}
-                    >
-                      {skill.name}
-                    </span>
-                    {skill.update_owner_ids.length > 0 && (
-                      <span className="inline-flex shrink-0 rounded-sm bg-accent-soft px-1.5 py-px text-caption font-semibold text-accent">
-                        Update
-                      </span>
-                    )}
-                    {pluginLabelForSkill(skill) && (
-                      <span className="inline-flex shrink-0 rounded-sm bg-bg-tertiary px-1.5 py-px text-caption font-semibold text-text-secondary">
-                        plugin · {pluginLabelForSkill(skill)}
-                      </span>
-                    )}
-                    {skill.parked && (
-                      <span className="inline-flex shrink-0 rounded-sm bg-bg-tertiary px-1.5 py-px text-caption font-semibold text-text-secondary">
-                        Parked
-                      </span>
-                    )}
-                    {invocationChipLabel(skill.invocation) && (
-                      <span className="inline-flex shrink-0 rounded-sm bg-bg-tertiary px-1.5 py-px text-caption font-semibold text-text-secondary">
-                        {invocationChipLabel(skill.invocation)}
-                      </span>
-                    )}
-                  </span>
-                  <span
-                    className="truncate text-small text-text-tertiary"
-                    title={skill.description ?? ""}
-                  >
-                    {skill.description ?? ""}
-                  </span>
-                  <SkillLocationCell skill={skill} />
-                  <span
-                    className={`whitespace-nowrap text-right text-small tabular-nums ${
-                      (stat?.last_30_days ?? 0) === 0
-                        ? "text-text-quaternary"
-                        : "text-text-tertiary"
-                    }`}
-                  >
-                    {stat?.last_30_days ?? 0}
-                  </span>
-                  <span className="whitespace-nowrap text-right text-small tabular-nums text-text-tertiary">
-                    {formatTokens(skill.skill_md_tokens)}
-                  </span>
-                </Button>
+                  glyphSize={GLYPH_SIZE}
+                  onOpen={() => onSelectSkill(skill.name, deploymentPathForSkill?.(skill))}
+                  onAct={(label) => void handleAct(label, skill)}
+                />
+                <SkillNameCell skill={skill} />
+                <SkillLocationCell locations={whereFacts(skill, DEFAULT_HARNESS_LIST).locations} />
+                <HarnessStack skill={skill} harnessList={DEFAULT_HARNESS_LIST} />
+                <TokenPairCell skill={skill} sortKey={tokenSort} />
               </div>
             );
           })}

--- a/apps/desktop/src/components/SkillList/SkillLocationCell.tsx
+++ b/apps/desktop/src/components/SkillList/SkillLocationCell.tsx
@@ -1,127 +1,90 @@
 // ============================================================================
-// SkillLocationCell - "Where does this skill really live, and who links to
-// it": one chip for the shared-root truth, one per symlink into it, one per
-// separate copy (drift risk), and the existing broken-link chip. Agents are
-// shown as harness brand marks; the relation glyph beside the mark says how
-// that agent reaches the skill (link, copy, broken), tooltips carry the words.
+// SkillLocationCell - the shared Location group: where on disk the skill
+// sits (global home folders, added project roots), independent of which
+// harnesses reach it. The project chip's tooltip is exception-only: it only
+// appears once the truncated name has actually clipped.
 // ============================================================================
 
-import { Copy, Link2, Unlink } from "lucide-react";
-import {
-  deploymentLinkTarget,
-  deploymentRelationText,
-  driftingCopies,
-  locationSummary,
-} from "@skill-studio/lib";
-import { homeRelativePath } from "@skill-studio/lib";
-import type { Deployment, InstalledSkill } from "@skill-studio/lib";
-import { HarnessIcon, harnessIdFromLabel } from "../ui/HarnessIcon";
-import { TooltipControl } from "../ui/TooltipControl";
+import { useLayoutEffect, useRef, useState } from "react";
+import { FolderGit2, Globe } from "lucide-react";
+import { RichTooltip } from "../ui/RichTooltip";
+import type { DiskLocation } from "./skill-row-state";
 
-interface SkillLocationCellProps {
-  skill: InstalledSkill;
-}
-
-/** The plain harness chip and each relation-to-shared-root chip share this base look. */
-const LOCATION_CHIP_BASE =
-  "inline-flex items-center gap-1 whitespace-nowrap rounded-sm border border-transparent px-1.5 py-0.5 text-caption tracking-[0.02em] text-text-secondary";
-const LOCATION_CHIP_CLASS = `${LOCATION_CHIP_BASE} bg-bg-tertiary`;
-
-/** The agent's brand mark, or its text label when no mark exists for it. */
-function AgentMark({ agent }: { agent: string }) {
-  const id = harnessIdFromLabel(agent);
-  if (!id) return <>{agent}</>;
-  return <HarnessIcon harness={id} size={13} />;
-}
-
-export function SkillLocationCell({ skill }: SkillLocationCellProps) {
-  const summary = locationSummary(skill);
-  const { truth, links, copies, broken } = summary;
-  const drifting = driftingCopies(summary);
-  const driftingPaths = new Set(drifting.map((d) => d.path));
-
-  // No shared-root copy and exactly one own directory: nothing to compare it
-  // against, so it's just the harness mark, no relation glyph.
-  if (!truth && links.length === 0 && copies.length === 1 && broken.length === 0) {
-    const [only] = copies;
-    return (
-      <span className="flex min-w-0 items-center gap-1 overflow-hidden">
-        <TooltipControl content={`${only.agent} · ${homeRelativePath(only.path)}`}>
-          <span className={LOCATION_CHIP_CLASS} aria-label={only.agent}>
-            <AgentMark agent={only.agent} />
-          </span>
-        </TooltipControl>
-      </span>
-    );
-  }
-
-  return (
-    <span className="flex min-w-0 items-center gap-1 overflow-hidden">
-      {truth && (
-        <TooltipControl content="Universal folder · canonical deployment">
-          <span
-            className={`${LOCATION_CHIP_CLASS} text-text-primary`}
-            aria-label="Universal folder, canonical deployment"
-          >
-            <HarnessIcon harness="shared" size={13} />
-          </span>
-        </TooltipControl>
+function LocationItem({ location }: { location: DiskLocation }) {
+  const nameRef = useRef<HTMLSpanElement>(null);
+  const [truncated, setTruncated] = useState(false);
+  const isProject = location.kind === "project";
+  // Measured after layout (and again on resize) so the tooltip exists before the first hover.
+  useLayoutEffect(() => {
+    if (!isProject) return;
+    const measure = () => {
+      const el = nameRef.current;
+      if (el) setTruncated(el.scrollWidth > el.clientWidth);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [isProject]);
+  const chip = (
+    <span
+      className={`inline-flex items-center gap-1 ${isProject ? "min-w-0 max-w-[120px]" : "shrink-0"}`}
+    >
+      {isProject ? (
+        <FolderGit2 size={13} className="shrink-0 text-text-tertiary" aria-hidden />
+      ) : (
+        <Globe size={13} className="shrink-0 text-text-tertiary" aria-hidden />
       )}
-      {links.map((d) => {
-        const target = deploymentLinkTarget(d);
-        return (
-          <TooltipControl
-            key={d.path}
-            content={
-              d.is_symlink
-                ? `${d.agent} · symlink → ${target ? homeRelativePath(target) : "unknown target"}`
-                : `${d.agent} · ${deploymentRelationText(d)}`
-            }
-          >
-            <span
-              className={LOCATION_CHIP_CLASS}
-              aria-label={`${d.agent}, linked to the Universal folder`}
-            >
-              <AgentMark agent={d.agent} />
-              <Link2 size={10} className="text-text-tertiary" />
-            </span>
-          </TooltipControl>
-        );
-      })}
-      {copies.map((d) => {
-        const isDrifting = driftingPaths.has(d.path);
-        return (
-          <TooltipControl
-            key={d.path}
-            content={`${d.agent} · separate copy at ${homeRelativePath(d.path)} · ${isDrifting ? "content differs" : "same content"}`}
-          >
-            <span
-              className={`${LOCATION_CHIP_BASE} ${isDrifting ? "bg-warning-soft" : "bg-bg-tertiary"}`}
-              aria-label={`${d.agent}, separate copy${isDrifting ? ", content differs" : ""}`}
-            >
-              <AgentMark agent={d.agent} />
-              <Copy size={10} className={isDrifting ? "text-warning" : "text-text-tertiary"} />
-            </span>
-          </TooltipControl>
-        );
-      })}
-      {broken.map((d) => (
-        <BrokenChip key={d.path} deployment={d} />
-      ))}
+      <span ref={nameRef} className="truncate text-small text-text-secondary">
+        {location.name}
+      </span>
     </span>
+  );
+  // The Global chip is already the word "Global" - there's no fact left for a tooltip to add. A
+  // project chip only gets one once its name has actually clipped.
+  if (!isProject || !truncated) return chip;
+  return (
+    <RichTooltip content={<span className="text-small">{location.name}</span>}>{chip}</RichTooltip>
   );
 }
 
-function BrokenChip({ deployment }: { deployment: Deployment }) {
+/** The "+N" chip's tooltip: one line per hidden location, its own kind icon and name. */
+function OverflowTooltip({ hidden }: { hidden: DiskLocation[] }) {
   return (
-    <TooltipControl content={`${deployment.agent} · broken link`}>
-      <span
-        className={`${LOCATION_CHIP_CLASS} text-error`}
-        aria-label={`${deployment.agent}, broken link`}
-      >
-        <AgentMark agent={deployment.agent} />
-        <Unlink size={10} />
-      </span>
-    </TooltipControl>
+    <div className="flex flex-col gap-1 text-small">
+      {hidden.map((location) => (
+        <span
+          key={`${location.kind}-${location.path}`}
+          className="flex items-center gap-1.5 text-text-tertiary"
+        >
+          {location.kind === "global" ? (
+            <Globe size={13} aria-hidden />
+          ) : (
+            <FolderGit2 size={13} aria-hidden />
+          )}
+          {location.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** Where the skill sits on disk: up to two locations, then a "+N" overflow. */
+export function SkillLocationCell({ locations }: { locations: DiskLocation[] }) {
+  if (locations.length === 0) {
+    return <span className="text-small text-text-tertiary">Nowhere</span>;
+  }
+  const shown = locations.slice(0, 2);
+  const hidden = locations.slice(2);
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2">
+      {shown.map((location) => (
+        <LocationItem key={`${location.kind}-${location.path}`} location={location} />
+      ))}
+      {hidden.length > 0 && (
+        <RichTooltip content={<OverflowTooltip hidden={hidden} />}>
+          <span className="shrink-0 text-small text-text-tertiary">+{hidden.length}</span>
+        </RichTooltip>
+      )}
+    </span>
   );
 }

--- a/apps/desktop/src/components/SkillList/SkillRowCells.tsx
+++ b/apps/desktop/src/components/SkillList/SkillRowCells.tsx
@@ -1,0 +1,314 @@
+// ============================================================================
+// SkillRowCells - the shared cell vocabulary for a Stack row: the list
+// header's cell class, the row frame, the name/invocation cell, the token
+// pair cell and its sortable header, and the leading cell (checkbox in
+// selection mode, otherwise the state glyph or a hover-only Ellipsis menu).
+// ============================================================================
+
+import type { ComponentProps, ReactNode } from "react";
+import {
+  ArrowDown,
+  CircleAlert,
+  CircleArrowDown,
+  CirclePause,
+  Ellipsis,
+  Hourglass,
+  OctagonAlert,
+  Sparkles,
+  TriangleAlert,
+  UserRound,
+} from "lucide-react";
+import { formatTokens } from "@skill-studio/lib";
+import type { InstalledSkill, SkillInvocationStats } from "@skill-studio/lib";
+import { Button } from "@skill-studio/ui";
+import type { SortMode } from "../../lib/skill-list-sort";
+import { CheckboxControl } from "../ui/CheckboxControl";
+import { RichTooltip } from "../ui/RichTooltip";
+import { TooltipControl } from "../ui/TooltipControl";
+import { isDecision, rowState } from "./skill-row-state";
+import type { RowLevel, RowState } from "./skill-row-state";
+
+/** The shared hit box: bigger than the 14px glyph so the button is easy to land a click on. Sized
+ * by the `--glyph-hit` CSS variable the row column template sets. */
+const HIT_CLASS =
+  "relative inline-flex size-(--glyph-hit) shrink-0 items-center justify-center rounded-sm transition-colors duration-150 hover:bg-bg-tertiary focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-border data-[popup-open]:bg-bg-tertiary";
+import { SkillRowMenu } from "./SkillRowMenu";
+
+/** The list header's cell. */
+export const HEADER_CELL_CLASS =
+  "h-9 text-caption font-medium tracking-[0.08em] text-text-tertiary uppercase";
+
+/** One row's frame: 36px, hairline below, no radius of its own. */
+export const ROW_CLASS =
+  "group grid h-9 w-full min-w-0 items-center rounded-none border-0 border-b border-border-subtle text-left last:border-b-0";
+
+const LEVEL_TEXT = {
+  error: "text-error",
+  warning: "text-warning",
+  info: "text-accent",
+  muted: "text-text-tertiary",
+} satisfies Record<RowLevel, string>;
+
+/** Selected-row treatment shared by the row: an accent border, softer fill, and a left accent bar. */
+export function selectedRowClass(selected: boolean): string {
+  return selected
+    ? "border-accent bg-accent-softer shadow-[inset_2px_0_0_var(--color-accent)]"
+    : "";
+}
+
+function glyphFor(state: RowState, size = 14): ReactNode {
+  switch (state.kind) {
+    case "violation":
+      return <OctagonAlert size={size} aria-hidden />;
+    case "rollup":
+      return state.level === "error" ? (
+        <CircleAlert size={size} aria-hidden />
+      ) : (
+        <TriangleAlert size={size} aria-hidden />
+      );
+    case "trial":
+      return <Hourglass size={size} aria-hidden />;
+    case "update":
+      return <CircleArrowDown size={size} aria-hidden />;
+    case "parked":
+      return <CirclePause size={size} aria-hidden />;
+  }
+}
+
+/** The state glyph's tooltip: the label in its level colour, the detail line when there is one,
+ * and a hint that the glyph opens a menu of fixes. */
+function StateTooltip({ state }: { state: RowState }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className={`font-medium ${LEVEL_TEXT[state.level]}`}>{state.label}</span>
+      {state.detail && <span className="text-text-secondary">{state.detail}</span>}
+      <span className="text-caption text-text-tertiary">Click for actions</span>
+    </div>
+  );
+}
+
+/** The Tokens cell's tooltip: the two costs a skill's Tokens column tracks - the prompt line
+ * every harness loads on every turn, and the full SKILL.md paid only when the skill runs. */
+function TokensTooltip({ skill }: { skill: InstalledSkill }) {
+  return (
+    <div className="grid grid-cols-1 gap-1 text-small">
+      <div className="flex flex-col gap-0.5">
+        <span className="tabular-nums text-text-primary">
+          {skill.description_tokens.toLocaleString()} tokens · prompt cost
+        </span>
+        <span className="text-caption text-text-tertiary">
+          name + description, loaded every turn by every harness that reaches it
+        </span>
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <span className="tabular-nums text-text-primary">
+          {skill.skill_md_tokens.toLocaleString()} tokens · full SKILL.md
+        </span>
+        <span className="text-caption text-text-tertiary">loaded when the skill is used</span>
+      </div>
+    </div>
+  );
+}
+
+const INVOCATION_HEADER = {
+  "user-only": "You run it",
+  "model-only": "The model runs it",
+} satisfies Record<"user-only" | "model-only", string>;
+
+/** Whether a skill is user-invoked only or model-invoked only; "both" needs no mark, so this
+ * renders nothing for the common case and the row stays quiet. The tooltip is one line - no
+ * per-harness control table, no invoke syntax. */
+function InvocationMark({ skill }: { skill: InstalledSkill }) {
+  if (skill.invocation === "both") return null;
+  const header = INVOCATION_HEADER[skill.invocation];
+  return (
+    <RichTooltip content={<span className="text-small">{header}</span>}>
+      <span
+        role="img"
+        aria-label={header}
+        className="inline-flex size-4 shrink-0 items-center justify-center text-text-tertiary"
+      >
+        {skill.invocation === "user-only" ? <UserRound size={12} /> : <Sparkles size={12} />}
+      </span>
+    </RichTooltip>
+  );
+}
+
+/** The skill's name: a truncated label plus its `InvocationMark`. Descriptions live in the
+ * detail panel, not the row. */
+export function SkillNameCell({ skill }: { skill: InstalledSkill }) {
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      <span className="min-w-0 truncate text-body text-text-primary">{skill.name}</span>
+      <InvocationMark skill={skill} />
+    </span>
+  );
+}
+
+/** Which of the two Tokens numbers sorts and highlights the column: the prompt cost every
+ * harness pays on every turn, or the full SKILL.md cost paid only on use. */
+export type TokenSortKey = "prompt" | "full";
+
+/** Rows in the table's sort order: `name` and `used` order as the Sort select says; `size`
+ * (the "largest" option, i.e. by tokens) orders by whichever of the two token numbers
+ * `tokenSort` has selected, ties broken by name. */
+export function sortRows(
+  skills: InstalledSkill[],
+  sort: SortMode,
+  statsBySkill: Map<string, SkillInvocationStats>,
+  tokenSort: TokenSortKey,
+): InstalledSkill[] {
+  const rows = [...skills];
+  if (sort === "name") {
+    rows.sort((a, b) => a.name.localeCompare(b.name));
+  } else if (sort === "used") {
+    rows.sort(
+      (a, b) =>
+        (statsBySkill.get(b.name)?.last_30_days ?? 0) -
+        (statsBySkill.get(a.name)?.last_30_days ?? 0),
+    );
+  } else {
+    const value = (skill: InstalledSkill) =>
+      tokenSort === "prompt" ? skill.description_tokens : skill.skill_md_tokens;
+    rows.sort((a, b) => value(b) - value(a) || a.name.localeCompare(b.name));
+  }
+  return rows;
+}
+
+/** Both token numbers for one skill: the prompt cost first (the "name: description" line every
+ * harness loads on every turn), then the full SKILL.md count. Whichever matches `sortKey` reads
+ * as the column's real value; the other stays quiet. */
+export function TokenPairCell({
+  skill,
+  sortKey,
+}: {
+  skill: InstalledSkill;
+  sortKey: TokenSortKey;
+}) {
+  const promptText = skill.description_tokens > 0 ? formatTokens(skill.description_tokens) : "–";
+  return (
+    <RichTooltip content={<TokensTooltip skill={skill} />}>
+      <span className="inline-flex items-baseline justify-end gap-1.5 tabular-nums text-small">
+        <span className={sortKey === "prompt" ? "text-text-primary" : "text-text-tertiary"}>
+          {promptText}
+        </span>
+        <span className={sortKey === "full" ? "text-text-primary" : "text-text-tertiary"}>
+          {formatTokens(skill.skill_md_tokens)}
+        </span>
+      </span>
+    </RichTooltip>
+  );
+}
+
+const TOKEN_SORT_LABEL = { prompt: "Prompt", full: "Full" } satisfies Record<TokenSortKey, string>;
+const TOKEN_SORT_TIP = {
+  prompt: "Sort by prompt cost: the name + description line every harness loads on every turn",
+  full: "Sort by SKILL.md size: loaded when the skill is used",
+} satisfies Record<TokenSortKey, string>;
+
+/** The Tokens header's two sort buttons, one per number `TokenPairCell` renders; clicking one
+ * sets it as the sort key without a separate direction control (both sort descending). Only
+ * changes row order while the table's own sort is "size" (largest); otherwise it just changes
+ * which number reads bold. */
+export function TokenPairHeader({
+  sortKey,
+  onSort,
+}: {
+  sortKey: TokenSortKey;
+  onSort: (key: TokenSortKey) => void;
+}) {
+  return (
+    <span className="inline-flex h-9 items-center justify-self-end gap-1">
+      {(["prompt", "full"] as const).map((key) => {
+        const active = key === sortKey;
+        return (
+          <TooltipControl key={key} content={TOKEN_SORT_TIP[key]}>
+            <Button
+              variant="ghost"
+              size="xs"
+              aria-pressed={active}
+              className={`h-auto gap-0.5 px-1 py-0 text-caption font-medium tracking-[0.08em] uppercase ${
+                active ? "text-text-primary" : "text-text-tertiary"
+              }`}
+              onClick={() => onSort(key)}
+            >
+              {TOKEN_SORT_LABEL[key]}
+              {active && <ArrowDown size={10} aria-hidden />}
+            </Button>
+          </TooltipControl>
+        );
+      })}
+    </span>
+  );
+}
+
+type CheckboxChange = ComponentProps<typeof CheckboxControl>["onCheckedChange"];
+
+interface LeadingCellProps {
+  skill: InstalledSkill;
+  selectionMode: boolean;
+  checked: boolean;
+  onCheckedChange: CheckboxChange;
+  glyphSize: number;
+  onOpen: () => void;
+  onAct: (label: string) => void;
+}
+
+/** The row's leading cell: a checkbox sized to exactly fill `--glyph-hit` in select mode (zero
+ * layout shift), otherwise the decision-state glyph (tooltipped) or the hover-only Ellipsis. */
+export function LeadingCell({
+  skill,
+  selectionMode,
+  checked,
+  onCheckedChange,
+  glyphSize,
+  onOpen,
+  onAct,
+}: LeadingCellProps) {
+  if (selectionMode) {
+    return (
+      <span
+        className="inline-flex size-(--glyph-hit) shrink-0 items-center justify-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CheckboxControl
+          checked={checked}
+          onCheckedChange={onCheckedChange}
+          ariaLabel={`Select ${skill.name}`}
+        />
+      </span>
+    );
+  }
+
+  const state: RowState | null = rowState(skill);
+  if (state && isDecision(state)) {
+    return (
+      <SkillRowMenu
+        skill={skill}
+        state={state}
+        trigger={
+          <RichTooltip content={<StateTooltip state={state} />}>
+            <span className={`inline-flex ${LEVEL_TEXT[state.level]}`}>
+              {glyphFor(state, glyphSize)}
+            </span>
+          </RichTooltip>
+        }
+        triggerClassName={HIT_CLASS}
+        triggerAriaLabel={state.label}
+        onOpen={onOpen}
+        onAct={onAct}
+      />
+    );
+  }
+  return (
+    <SkillRowMenu
+      skill={skill}
+      state={state}
+      trigger={<Ellipsis size={glyphSize} aria-hidden />}
+      triggerClassName={`${HIT_CLASS} text-text-tertiary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 data-[popup-open]:opacity-100 transition-opacity duration-150`}
+      triggerAriaLabel={`Actions · ${skill.name}`}
+      onOpen={onOpen}
+      onAct={onAct}
+    />
+  );
+}

--- a/apps/desktop/src/components/SkillList/SkillRowMenu.tsx
+++ b/apps/desktop/src/components/SkillList/SkillRowMenu.tsx
@@ -1,0 +1,64 @@
+// ============================================================================
+// SkillRowMenu - the row's one menu: fixes first when the row has a decision
+// to make, then the open/park verbs every row offers.
+// ============================================================================
+
+import type { ReactNode } from "react";
+import type { InstalledSkill } from "@skill-studio/lib";
+import { MenuControl, MenuItem, MenuSeparator } from "../ui/MenuControl";
+import { fixesFor } from "./skill-row-state";
+import type { RowState } from "./skill-row-state";
+
+interface SkillRowMenuProps {
+  skill: InstalledSkill;
+  state: RowState | null;
+  trigger: ReactNode;
+  triggerClassName?: string;
+  triggerAriaLabel?: string;
+  onOpen: () => void;
+  onAct: (label: string) => void;
+}
+
+export function SkillRowMenu({
+  skill,
+  state,
+  trigger,
+  triggerClassName,
+  triggerAriaLabel,
+  onOpen,
+  onAct,
+}: SkillRowMenuProps) {
+  const fixes = state ? fixesFor(state) : [];
+  return (
+    <span onClick={(e) => e.stopPropagation()}>
+      <MenuControl
+        trigger={trigger}
+        triggerClassName={triggerClassName}
+        triggerAriaLabel={triggerAriaLabel}
+        popupClassName="min-w-[220px]"
+      >
+        <div className="px-2 py-1.5 text-small text-text-primary">
+          {state ? state.label : skill.name}
+        </div>
+        {state?.detail && (
+          <div className="px-2 pb-1.5 text-caption text-text-tertiary">{state.detail}</div>
+        )}
+        <MenuSeparator />
+        {fixes.length > 0 && (
+          <>
+            {fixes.map((fix) => (
+              <MenuItem key={fix} onClick={() => onAct(fix)}>
+                {fix}
+              </MenuItem>
+            ))}
+            <MenuSeparator />
+          </>
+        )}
+        <MenuItem onClick={onOpen}>Open skill</MenuItem>
+        <MenuItem onClick={() => onAct(skill.parked ? "Unpark" : "Park")}>
+          {skill.parked ? "Unpark" : "Park"}
+        </MenuItem>
+      </MenuControl>
+    </span>
+  );
+}

--- a/apps/desktop/src/components/SkillList/skill-row-state.tsx
+++ b/apps/desktop/src/components/SkillList/skill-row-state.tsx
@@ -1,0 +1,343 @@
+// ============================================================================
+// skill-row-state - The single highest-ranked thing a row needs to say about
+// a skill, and `whereFacts`, the disk-location/harness-reach model every
+// row renders.
+// ============================================================================
+
+import {
+  AGENT_MATRIX_LABELS,
+  driftingCopies,
+  isBlockingSpecViolation,
+  locationSummary,
+  parentDirectory,
+  trialHoursLeft,
+} from "@skill-studio/lib";
+import type { AgentId, Deployment, InstalledSkill } from "@skill-studio/lib";
+import { buildScopeGroups, skillRollup } from "../SkillDetail/skill-location-status";
+import { harnessIdFromLabel } from "../ui/HarnessIcon";
+
+export type RowLevel = "error" | "warning" | "info" | "muted";
+/** Which ladder rung produced the state; picks the glyph in SkillRowCells. */
+type RowKind = "violation" | "rollup" | "trial" | "update" | "parked";
+
+export interface RowState {
+  kind: RowKind;
+  level: RowLevel;
+  label: string;
+  detail: string | null;
+  action: string | null;
+}
+
+/** "Parked · Aug 25, 2026" / "Parked" — copied from InstalledSkillHeader's chip. */
+function parkedChipLabel(parkedAt: string | null | undefined): string {
+  if (!parkedAt) return "Parked";
+  const date = new Date(parkedAt);
+  if (Number.isNaN(date.getTime())) return "Parked";
+  return `Parked · ${date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}`;
+}
+
+/** "Trial · 17 h" / "Trial · <1 h" / "Trial · expired" — copied from InstalledSkillHeader's chip. */
+function trialChipLabel(expiresAt: string): string {
+  const hours = trialHoursLeft(expiresAt);
+  if (hours < 0) return "Trial · expired";
+  if (hours < 1) return "Trial · <1 h";
+  return `Trial · ${hours} h`;
+}
+
+/** The one thing this row most needs to say, in ladder order: blocking spec
+ * violation, then the folder rollup, then a trial, an update, or parked.
+ * `null` when the skill is unremarkable. */
+export function rowState(skill: InstalledSkill): RowState | null {
+  const blocking = skill.spec_violations.filter(isBlockingSpecViolation);
+  if (blocking.length > 0) {
+    return {
+      kind: "violation",
+      level: "error",
+      label: "Blocking spec violation",
+      detail: blocking[0],
+      action: "Fix YAML",
+    };
+  }
+
+  const rollup = skillRollup(skill, buildScopeGroups(skill));
+  const [first, second] = rollup.tip.split("\n");
+  if (rollup.level === "error") {
+    return {
+      kind: "rollup",
+      level: "error",
+      label: first,
+      detail: second ?? null,
+      action: "Repair",
+    };
+  }
+  if (rollup.level === "warning") {
+    const hasDrift = driftingCopies(locationSummary(skill)).length > 0;
+    return {
+      kind: "rollup",
+      level: "warning",
+      label: first,
+      detail: second ?? null,
+      action: hasDrift ? "Compare" : null,
+    };
+  }
+
+  const [trial] = skill.trials;
+  if (trial) {
+    return {
+      kind: "trial",
+      level: "info",
+      label: trialChipLabel(trial.expires_at),
+      detail: null,
+      action: "Keep",
+    };
+  }
+  if (skill.update_owner_ids.length > 0) {
+    return {
+      kind: "update",
+      level: "info",
+      label: "Update available",
+      detail: null,
+      action: "Update",
+    };
+  }
+  if (skill.parked) {
+    return {
+      kind: "parked",
+      level: "muted",
+      label: parkedChipLabel(skill.parked_at),
+      detail: null,
+      action: "Unpark",
+    };
+  }
+  return null;
+}
+
+type DiskLocationKind = "global" | "project";
+
+/** One deployment's fact sheet, for a `DiskLocation`'s or `HarnessReach`'s
+ * per-deployment line. `scope`/`resolvedPath` back a linked entry's
+ * "→ target" line and a Globe-vs-project icon. */
+interface LocationEntry {
+  harness: AgentId | "shared";
+  label: string;
+  path: string;
+  how: How;
+  readOnly: boolean;
+  disabled: boolean;
+  scope: DiskLocationKind;
+  resolvedPath: string | null;
+}
+
+/** How one deployment reaches the skill: the Universal folder's own copy, a
+ * symlink into it, an own copy elsewhere, or a symlink that no longer
+ * resolves. */
+type How = "universal" | "linked" | "own" | "broken";
+
+/** One place a skill lives on disk - the Universal folder's global scope, or
+ * a project root - and every deployment installed there. */
+export interface DiskLocation {
+  kind: DiskLocationKind;
+  name: string;
+  path: string;
+  entries: LocationEntry[];
+}
+
+/** One first-class harness, whether it reaches the skill at all, and how
+ * (worst deployment wins), for the Harnesses group. */
+export interface HarnessReach {
+  harness: AgentId;
+  label: string;
+  reached: boolean;
+  how: How | null;
+  disabled: boolean;
+  entries: LocationEntry[];
+}
+
+/** The Universal folder (`~/.agents/skills`) itself: whether the skill has a
+ * copy there. */
+export interface Universal {
+  present: boolean;
+  path: string | null;
+}
+
+interface WhereFacts {
+  locations: DiskLocation[];
+  universal: Universal;
+  harnesses: HarnessReach[];
+}
+
+/** One harness `whereFacts` can render, in the order the Harnesses group
+ * draws it. */
+export interface HarnessListEntry {
+  label: string;
+  harness: AgentId;
+}
+
+/** `AGENT_MATRIX_LABELS`'s six first-class agents, in order - `whereFacts`'
+ * default list. */
+export const DEFAULT_HARNESS_LIST: HarnessListEntry[] = AGENT_MATRIX_LABELS.flatMap((label) => {
+  const harness = harnessIdFromLabel(label);
+  return harness && harness !== "shared" ? [{ label, harness }] : [];
+});
+
+/** `shared` sorts first, then `harnessList` order - the Universal folder is
+ * the source every harness reaches through, so it leads a location's or
+ * harness list's entries. */
+function harnessRank(harness: AgentId | "shared", harnessList: HarnessListEntry[]): number {
+  if (harness === "shared") return -1;
+  return harnessList.findIndex((entry) => entry.harness === harness);
+}
+
+/** Resolves a deployment's `agent` display label to a harness id: the six
+ * first-class labels `harnessIdFromLabel` knows, or a label match against
+ * the harness list itself. */
+function resolveHarness(
+  agentLabel: string,
+  harnessList: HarnessListEntry[],
+): AgentId | "shared" | null {
+  return (
+    harnessIdFromLabel(agentLabel) ??
+    harnessList.find((entry) => entry.label === agentLabel)?.harness ??
+    null
+  );
+}
+
+/** How one deployment reaches the skill: a dangling symlink is "broken"
+ * first, else the Universal folder's own copy (or the shared root itself) is
+ * "universal", else a symlink into it is "linked", else it's its own
+ * independent copy. */
+function deploymentHow(d: Deployment, harness: AgentId | "shared"): How {
+  if (d.is_symlink && d.resolved_path === null) return "broken";
+  if (harness === "shared" || d.backing.kind === "canonical") return "universal";
+  if (
+    d.backing.kind === "linked-to" ||
+    (d.is_symlink && /\/\.agents\/skills\//.test(d.resolved_path ?? ""))
+  )
+    return "linked";
+  return "own";
+}
+
+function locationEntry(d: Deployment, harness: AgentId | "shared"): LocationEntry {
+  return {
+    harness,
+    label: harness === "shared" ? "Universal folder" : d.agent,
+    path: d.path,
+    how: deploymentHow(d, harness),
+    readOnly: d.mutability === "read-only",
+    disabled: d.disabled,
+    scope: d.scope === "project" && d.project_path ? "project" : "global",
+    resolvedPath: d.resolved_path ?? null,
+  };
+}
+
+/** Worst-wins ordering for a `HarnessReach`'s single `how`: a broken link is
+ * worse news than a healthy one anywhere else. */
+const HOW_SEVERITY = { broken: 3, linked: 2, own: 1, universal: 0 } satisfies Record<How, number>;
+
+/** Splits a skill's deployments into the disk locations they sit in and the
+ * harnesses that reach them, plus the Universal folder's own facts.
+ * `harnessList` defaults to `DEFAULT_HARNESS_LIST`'s six. */
+export function whereFacts(
+  skill: InstalledSkill,
+  harnessList: HarnessListEntry[] = DEFAULT_HARNESS_LIST,
+): WhereFacts {
+  const globalDeployments = skill.deployments.filter((d) => d.scope !== "project");
+
+  const locationsByKey = new Map<string, DiskLocation>();
+  if (globalDeployments.length > 0) {
+    locationsByKey.set("global", { kind: "global", name: "Global", path: "~", entries: [] });
+  }
+  for (const d of skill.deployments) {
+    if (d.scope !== "project" || !d.project_path) continue;
+    const key = `project:${d.project_path}`;
+    if (!locationsByKey.has(key)) {
+      locationsByKey.set(key, {
+        kind: "project",
+        name: d.project_path.split("/").filter(Boolean).pop() ?? d.project_path,
+        path: d.project_path,
+        entries: [],
+      });
+    }
+  }
+
+  let universalPresent = false;
+  let universalPath: string | null = null;
+
+  for (const d of skill.deployments) {
+    const harness = resolveHarness(d.agent, harnessList);
+    if (!harness) continue;
+    const entry = locationEntry(d, harness);
+    if (harness === "shared") {
+      universalPresent = true;
+      universalPath = parentDirectory(d.path);
+    }
+    const key = d.scope === "project" && d.project_path ? `project:${d.project_path}` : "global";
+    locationsByKey.get(key)?.entries.push(entry);
+  }
+
+  const locations = [...locationsByKey.values()]
+    .map((location) => ({
+      ...location,
+      entries: [...location.entries].sort(
+        (a, b) => harnessRank(a.harness, harnessList) - harnessRank(b.harness, harnessList),
+      ),
+    }))
+    .sort((a, b) => {
+      if (a.kind === "global") return -1;
+      if (b.kind === "global") return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+  const harnesses: HarnessReach[] = harnessList.map(({ harness, label }) => {
+    // Global first, then projects - the same order the harness's own tooltip lines read.
+    const entries = locations.flatMap((l) => l.entries.filter((e) => e.harness === harness));
+    const reached = entries.length > 0;
+    const how = reached
+      ? entries.reduce<How>(
+          (worst, e) => (HOW_SEVERITY[e.how] > HOW_SEVERITY[worst] ? e.how : worst),
+          entries[0].how,
+        )
+      : null;
+    return {
+      harness,
+      label,
+      reached,
+      how,
+      disabled: reached && entries.every((e) => e.disabled),
+      entries,
+    };
+  });
+
+  return {
+    locations,
+    universal: {
+      present: universalPresent,
+      path: universalPath,
+    },
+    harnesses,
+  };
+}
+
+/** The fix or fixes each ladder rung offers from the glyph, independent of
+ * `state.action`. */
+export function fixesFor(state: RowState): string[] {
+  switch (state.kind) {
+    case "violation":
+      return ["Fix YAML"];
+    case "rollup":
+      return state.level === "error" ? ["Fix link"] : [state.action ?? "Compare", "Convert"];
+    case "trial":
+      return ["Keep"];
+    case "update":
+      return ["Pull latest"];
+    case "parked":
+      return ["Unpark"];
+  }
+}
+
+/** Whether the row has a state worth surfacing a glyph or menu for - every
+ * kind except parked, which is a quiet fact rather than something to decide
+ * about. */
+export function isDecision(state: RowState | null): boolean {
+  return state !== null && state.kind !== "parked";
+}

--- a/apps/desktop/src/components/ui/RichTooltip.tsx
+++ b/apps/desktop/src/components/ui/RichTooltip.tsx
@@ -1,0 +1,27 @@
+// ============================================================================
+// RichTooltip - a structured tooltip with icons, a grid of columns, or mono
+// paths, built straight on the kit's Tooltip primitives with the same
+// sideOffset and shell TooltipControl uses.
+// ============================================================================
+
+import type { ReactElement, ReactNode } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@skill-studio/ui";
+
+interface RichTooltipProps {
+  content: ReactNode;
+  children: ReactElement;
+}
+
+export function RichTooltip({ content, children }: RichTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger render={children} />
+      <TooltipContent
+        sideOffset={6}
+        className="max-w-none flex-col items-start gap-0.5 bg-bg-elevated text-small text-text-primary shadow-md ring-1 ring-border [&>[data-slot=tooltip-arrow]]:hidden"
+      >
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/docs/skill-row-design-decision.md
+++ b/docs/skill-row-design-decision.md
@@ -1,0 +1,55 @@
+# Skill row — decided from the `PROTO:skill-row` picker (2026-09-12)
+
+The Skills list row and the Home inbox row share one design. It was chosen from an in-place
+prototype picker over eleven rounds; the picker and its variants are deleted.
+
+## Direction: the Stack row
+
+- Columns: glyph hit area · Skill name · Location · Harnesses · Prompt / Full tokens. Rows are
+  36px (`h-9`). No Description column.
+- The leading glyph is the action: the row's one state icon (update, trial, broken, drift,
+  invocation) with a menu on hover. Colour and icons carry state; words do not.
+- Location shows the Global chip and up to two project chips, then `+N`.
+- Harnesses is an overlapping avatar-group stack: the Universal folder disc first when present,
+  then one disc per reached harness up to five, then a `+N` disc.
+- Harness disc badges: a small link glyph when the harness reaches the skill only through the
+  Universal folder; a red broken-link glyph when that link is broken.
+- Disabled treatment: **Muted**. A disabled or parked disc keeps its shape and dims the glyph to
+  `--color-icon-muted` at `opacity-60`. Parked marks every disc and dims the whole row; disabled
+  marks one disc.
+
+## Tooltips
+
+Every harness disc has a one-line tooltip because an 11px icon cannot show how it reaches the
+skill: `<glyph> <harness> · <how>[ · <state>]`.
+
+- how: `linked to Universal folder` / `source in Universal folder` / `own copy`; a broken link
+  replaces it with `link broken` in the error tone.
+- state: `disabled` or `parked` in the warning tone, appended after the how-word.
+- The Universal disc says `Universal folder`. The `+N` disc lists the hidden harnesses.
+- Location: `+N` lists the hidden projects; a project chip has a tooltip with its full name
+  only when it is truncated. The Global chip never has one.
+- The invocation glyph says `You run it` or `The model runs it`. Nothing else in the row has a
+  tooltip.
+
+## Rejected
+
+- Per-harness invocation tables and frontmatter-key captions in tooltips: a dictionary, not a
+  row.
+- A Description column: the name column needs the width more.
+- Native `title` attributes: inconsistent look and delay.
+- Six- and ten-harness toggles, "linked by" lists on the Universal disc, verbose disabled
+  reasons, "N copies", "own copy" next to the Global chip: restate what the row already shows.
+- Path tooltips (mono path only) and Map tooltips (whole-stack grid): "people know a global
+  skill is at the home directory"; they spell out the obvious.
+- Exception-only tooltips (nothing on a healthy disc): went too far, the icons are too small to
+  tell symlinked from own copy.
+- Gallery caption headers: the list must look like the end product.
+- Disabled treatments Slash (thin diagonal line) and Dashed (dashed outline): the line alone
+  did not read as disabled once the glyph stayed full tone; Muted is enough on its own.
+- Earlier row variants Ghost, Reach, Bare, Lead: replaced by the Stack row in earlier rounds.
+
+## Open
+
+- Read-only copies (plugin cache, read-only own copy) have no mark in the row; the detail view
+  carries that.


### PR DESCRIPTION
Stacked on #74 (which stacks on #73). Merge those first; this PR then shows only the skill row commit.

## What

The Skills list and the Home inbox share one row design, the **Stack row**, chosen from an in-place prototype picker over twelve rounds:

- Columns: state glyph · Skill · Location · Harnesses · Prompt / Full tokens. The Description and Uses columns and the name chips are gone.
- The leading glyph is the action: one state icon (update, trial, broken, drift, invocation) with a menu on hover. Park and Unpark call the lifecycle API; every fix item opens the skill detail, where those flows live.
- Location: the Global chip plus up to two project chips, then `+N`.
- Harnesses: an avatar-group stack, Universal folder disc first, then one disc per reached harness up to five, then `+N`. A small link badge marks a harness that reaches the skill through the Universal folder; a red broken-link badge marks a broken link.
- Disabled treatment is **Muted**: a disabled or parked harness dims its glyph. Parked also dims the whole row.
- Every harness disc has a one-line tooltip: `<harness> · <how> [· <state>]`, because an 11px icon cannot show how the harness reaches the skill.

The decision and the rejected options are recorded in `docs/skill-row-design-decision.md`. The prototype directory and its dev-only mount are deleted.

## New files

`HarnessMark`, `HarnessStack`, `SkillRowCells`, `SkillRowMenu`, `skill-row-state` under `apps/desktop/src/components/SkillList/`, and `ui/RichTooltip`.

## Judgment calls

- Select-all lives in the header grid, aligned with the row checkboxes; the toolbar checkbox was removed.
- The Prompt/Full header toggle reorders rows only when the sort menu is set to Size; otherwise it switches which value is bold.
- Remove was dropped from the row menu.

## Open

Read-only copies (plugin cache, read-only own copy) have no mark in the row; the detail view carries that.

## Checks

`oxfmt --check`, `oxlint`, and `tsc --noEmit` pass on `apps/desktop/src`. Real rows still need a look in the desktop app; the browser has no Tauri backend, so it shows zero rows.

Created with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI refactor plus in-row Park/Unpark API calls; behavior depends on `whereFacts`/`rowState` matching existing skill lifecycle and detail flows.
> 
> **Overview**
> Introduces the **Stack row** as the shared layout for the Skills list and Home inbox: state glyph · Skill · Location · Harnesses · Prompt/Full tokens (36px rows, no Description or Uses columns).
> 
> **Skills list** is rebuilt around extracted pieces: `skill-row-state` (`rowState`, `whereFacts`, `DEFAULT_HARNESS_LIST`), `HarnessStack`/`HarnessMark` (overlapping harness discs with link/broken badges and muted disabled/parked treatment), simplified `SkillLocationCell` (Global + project chips, not per-harness relation chips), and `SkillRowCells`/`SkillRowMenu` (leading state icon or hover ellipsis menu; Park/Unpark call the lifecycle API; other fixes open detail). Tokens show prompt + full SKILL.md with a header toggle that sorts when sort mode is Size. Selection checkboxes move into the table header grid.
> 
> **Home** drops inline `HarnessBadges` and uses the same `HarnessStack`.
> 
> Adds **`RichTooltip`** for structured row tooltips and records the design in `docs/skill-row-design-decision.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73261c42935b62c91f7350f4fa5f7b43c9bd5f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->